### PR TITLE
Add MatrixTerminal follow-up scene

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import LegoBuildMode from './components/LegoBuildMode';
 import LegoInventory from './components/LegoInventory';
 import LittleAlchemy from './components/LittleAlchemy';
 import TheMatrix from './components/TheMatrix';
+import MatrixTerminal from './components/MatrixTerminal';
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/lego-inventory" element={<LegoInventory />} />
           <Route path="/little-alchemy" element={<LittleAlchemy />} />
           <Route path="/the-matrix" element={<TheMatrix />} />
+          <Route path="/matrix-terminal" element={<MatrixTerminal />} />
           <Route path="*" element={<Navigate to="/snack-trail" />} />
         </Routes>
       </div>

--- a/src/__tests__/TheMatrix.test.jsx
+++ b/src/__tests__/TheMatrix.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TheMatrix from '../components/TheMatrix';
+import { MemoryRouter } from 'react-router-dom';
 
 // helper to enter the matrix by submitting a name
 async function enterMatrix(name = 'Neo') {
-  render(<TheMatrix />);
+  render(
+    <MemoryRouter initialEntries={["/the-matrix"]}>
+      <TheMatrix />
+    </MemoryRouter>
+  );
   const input = screen.getByPlaceholderText(/player name/i);
   await userEvent.type(input, name);
   await userEvent.click(screen.getByRole('button', { name: /enter/i }));
@@ -19,8 +24,8 @@ test('pill buttons appear and change state when clicked', async () => {
   expect(redButton).toBeInTheDocument();
   expect(blueButton).toBeInTheDocument();
 
-  // clicking red pill hides the buttons and shows red pill text
+  // clicking red pill navigates to the terminal
   await userEvent.click(redButton);
-  expect(screen.getByText(/you take the red pill/i)).toBeInTheDocument();
+  expect(await screen.findByText(/matrix terminal/i)).toBeInTheDocument();
 });
 

--- a/src/components/MatrixTerminal.jsx
+++ b/src/components/MatrixTerminal.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+export default function MatrixTerminal() {
+  const [code, setCode] = useState('');
+  const [message, setMessage] = useState('');
+  const secret = 'thereisnospoon';
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (code.toLowerCase() === secret) {
+      setMessage('Access granted. Welcome to the real world.');
+    } else {
+      setMessage('Access denied. Try again.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-6">
+      <h1 className="text-4xl font-bold">Matrix Terminal</h1>
+      <p className="text-lg">You take the red pill and follow the white rabbit...</p>
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="Enter passcode"
+          className="px-4 py-2 rounded bg-black border border-green-700 placeholder-green-700 focus:outline-none"
+        />
+        <button type="submit" className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600">
+          Hack
+        </button>
+      </form>
+      {message && <p className="text-xl">{message}</p>}
+    </div>
+  );
+}

--- a/src/components/TheMatrix.jsx
+++ b/src/components/TheMatrix.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function TheMatrix() {
   const [name, setName] = useState('');
   const [entered, setEntered] = useState(false);
   const [pill, setPill] = useState(null);
+  const navigate = useNavigate();
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -43,7 +45,7 @@ export default function TheMatrix() {
           <p className="text-xl">You are now inside the Matrix.</p>
           <div className="flex space-x-4">
             <button
-              onClick={() => setPill('red')}
+              onClick={() => navigate('/matrix-terminal')}
               className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500"
             >
               Red Pill
@@ -58,16 +60,6 @@ export default function TheMatrix() {
         </>
       )}
 
-      {pill === 'red' && (
-        <>
-          <p className="text-xl">You take the red pill and follow the white rabbit.</p>
-          <div className="w-full overflow-hidden h-10">
-            <div className="animate-marquee whitespace-nowrap">
-              {Array(20).fill('0101010101111001010101').join(' ')}
-            </div>
-          </div>
-        </>
-      )}
 
       {pill === 'blue' && (
         <p className="text-xl">You take the blue pill and wake up in your bed.</p>


### PR DESCRIPTION
## Summary
- create `MatrixTerminal` puzzle scene
- navigate to terminal when the red pill is chosen
- add route for `/matrix-terminal`
- update unit test for new navigation behavior

## Testing
- `npm test -- --runTestsByPath src/__tests__/TheMatrix.test.jsx` *(fails: react-scripts not found)*