### PR TITLE
Add Naoe quotes to MatrixTerminal

### DIFF
--- a/src/__tests__/MatrixTerminal.test.jsx
+++ b/src/__tests__/MatrixTerminal.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MatrixTerminal from '../components/MatrixTerminal';
+
+// helper to submit passcode
+async function submitCode(code) {
+  render(<MatrixTerminal />);
+  const input = screen.getByPlaceholderText(/enter passcode/i);
+  await userEvent.type(input, code);
+  await userEvent.click(screen.getByRole('button', { name: /hack/i }));
+}
+
+test('shows a Naoe quote when passcode is correct', async () => {
+  await submitCode('thereisnospoon');
+  const message = await screen.findByText(/access granted/i);
+  expect(message.textContent).toMatch(/— Naoe/);
+});
+
+test('shows access denied when passcode is wrong', async () => {
+  await submitCode('wrong');
+  expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+});

--- a/src/components/MatrixTerminal.jsx
+++ b/src/components/MatrixTerminal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { NAOE_QUOTES } from '../data/naoeQuotes';
 
 export default function MatrixTerminal() {
   const [code, setCode] = useState('');
@@ -8,7 +9,8 @@ export default function MatrixTerminal() {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (code.toLowerCase() === secret) {
-      setMessage('Access granted. Welcome to the real world.');
+      const quote = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
+      setMessage(`Access granted. Welcome to the real world. ${quote.text} — ${quote.attribution}`);
     } else {
       setMessage('Access denied. Try again.');
     }

--- a/src/data/naoeQuotes.js
+++ b/src/data/naoeQuotes.js
@@ -1,0 +1,22 @@
+export const NAOE_QUOTES = [
+  { text: "Fearing the rainstorm will not prevent the flood.", attribution: 'Naoe' },
+  { text: "A single drop of water can start a ripple that becomes a wave.", attribution: 'Naoe' },
+  { text: "The sharpest blade cannot cut the wind.", attribution: 'Naoe' },
+  { text: "The moon’s reflection is not the moon itself.", attribution: 'Naoe' },
+  { text: "A shadow cannot exist without light.", attribution: 'Naoe' },
+  { text: "Roots unseen still anchor the tallest tree.", attribution: 'Naoe' },
+  { text: "The mountain does not notice the footsteps of the traveler.", attribution: 'Naoe' },
+  { text: "Patience is the silent strength of the bamboo.", attribution: 'Naoe' },
+  { text: "The river flows, whether watched or not.", attribution: 'Naoe' },
+  { text: "To chase two rabbits is to catch none.", attribution: 'Naoe' },
+  { text: "A closed fist cannot hold water.", attribution: 'Naoe' },
+  { text: "The crane stands alone, yet is never lonely.", attribution: 'Naoe' },
+  { text: "The spider’s web is delicate, but it endures the storm.", attribution: 'Naoe' },
+  { text: "The falling leaf returns to its roots.", attribution: 'Naoe' },
+  { text: "The stone in the stream shapes the water, and is shaped in return.", attribution: 'Naoe' },
+  { text: "Even the smallest lantern can banish the darkness.", attribution: 'Naoe' },
+  { text: "A broken branch still reaches for the sun.", attribution: 'Naoe' },
+  { text: "The silent pond reflects the sky.", attribution: 'Naoe' },
+  { text: "The wind whispers secrets to those who listen.", attribution: 'Naoe' },
+  { text: "Only in stillness does the heart find its path.", attribution: 'Naoe' }
+];


### PR DESCRIPTION
## Summary
- provide a list of meditative quotes in `src/data/naoeQuotes.js`
- show a random quote when the correct passcode is entered in `MatrixTerminal`
- test MatrixTerminal interactions

## Testing
- `npm test` *(fails: react-scripts not found)*