### PR TITLE
Add Matrix transition screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import LegoInventory from './components/LegoInventory';
 import LittleAlchemy from './components/LittleAlchemy';
 import TheMatrix from './components/TheMatrix';
 import MatrixTerminal from './components/MatrixTerminal';
+import MatrixTransition from './components/MatrixTransition';
 
 export default function App() {
   return (
@@ -26,6 +27,7 @@ export default function App() {
           <Route path="/little-alchemy" element={<LittleAlchemy />} />
           <Route path="/the-matrix" element={<TheMatrix />} />
           <Route path="/matrix-terminal" element={<MatrixTerminal />} />
+          <Route path="/matrix-transition" element={<MatrixTransition />} />
           <Route path="*" element={<Navigate to="/snack-trail" />} />
         </Routes>
       </div>

--- a/src/__tests__/MatrixTerminal.test.jsx
+++ b/src/__tests__/MatrixTerminal.test.jsx
@@ -1,19 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import MatrixTerminal from '../components/MatrixTerminal';
+import MatrixTransition from '../components/MatrixTransition';
 
-// helper to submit passcode
+// helper to submit passcode within router
 async function submitCode(code) {
-  render(<MatrixTerminal />);
+  render(
+    <MemoryRouter initialEntries={["/matrix-terminal"]}>
+      <Routes>
+        <Route path="/matrix-terminal" element={<MatrixTerminal />} />
+        <Route path="/matrix-transition" element={<MatrixTransition />} />
+      </Routes>
+    </MemoryRouter>
+  );
   const input = screen.getByPlaceholderText(/enter passcode/i);
   await userEvent.type(input, code);
   await userEvent.click(screen.getByRole('button', { name: /hack/i }));
 }
 
-test('shows a Naoe quote when passcode is correct', async () => {
+test('navigates to transition screen on correct passcode', async () => {
   await submitCode('thereisnospoon');
-  const message = await screen.findByText(/Naoe/, {}, { timeout: 5000 });
-  expect(message.textContent).toMatch(/Access granted/);
+  const quote = await screen.findByText(/Naoe/, {}, { timeout: 5000 });
+  expect(quote).toBeInTheDocument();
 });
 
 test('shows access denied when passcode is wrong', async () => {

--- a/src/components/MatrixTerminal.jsx
+++ b/src/components/MatrixTerminal.jsx
@@ -1,24 +1,24 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { NAOE_QUOTES } from '../data/naoeQuotes';
 import useTypewriterEffect from './useTypewriterEffect';
 
 export default function MatrixTerminal() {
   const [code, setCode] = useState('');
   const [message, setMessage] = useState('');
-  const [typedMessage, done] = useTypewriterEffect(message);
+  const [typedMessage] = useTypewriterEffect(message);
+  const navigate = useNavigate();
   const secret = 'thereisnospoon';
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (code.toLowerCase() === secret) {
       const quote = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
-      setMessage(`Access granted. Welcome to the real world. ${quote.text} — ${quote.attribution}`);
+      navigate('/matrix-transition', { state: { quote } });
     } else {
       setMessage('Access denied. Try again.');
     }
   };
-
-  const success = message.startsWith('Access granted');
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-6">
@@ -37,12 +37,7 @@ export default function MatrixTerminal() {
         </button>
       </form>
       {message && (
-        <p
-          className="text-xl text-green-400"
-          style={success ? { textShadow: '0 0 8px #00ff00' } : undefined}
-        >
-          {success ? typedMessage : message}
-        </p>
+        <p className="text-xl text-green-400">{typedMessage}</p>
       )}
     </div>
   );

--- a/src/components/MatrixTransition.jsx
+++ b/src/components/MatrixTransition.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function MatrixTransition() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const quote = state?.quote;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate('/snack-trail');
+    }, 3500);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  if (!quote) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-black text-green-400 font-mono">
+        <p>No quote provided.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Matrix Transition</h1>
+      <div className="w-64 h-2 bg-green-900 overflow-hidden rounded">
+        <div className="loading-bar h-full bg-green-500" />
+      </div>
+      <p className="neon-text text-center text-xl px-4">
+        {quote.text} — {quote.attribution}
+      </p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,3 +21,17 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 } 
+
+@keyframes matrix-progress {
+  from { width: 0%; }
+  to { width: 100%; }
+}
+
+.loading-bar {
+  animation: matrix-progress 3s linear forwards;
+}
+
+.neon-text {
+  color: #39ff14;
+  text-shadow: 0 0 5px #39ff14, 0 0 10px #39ff14, 0 0 20px #39ff14;
+}


### PR DESCRIPTION
## Summary
- add `MatrixTransition` with progress bar and neon quote style
- redirect MatrixTerminal success to new transition screen
- automatically move from transition to `/snack-trail`
- wire up the new route in `App.js`
- update tests for MatrixTerminal navigation
- add matrix styles to `index.css`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*