### PR TITLE
Add MatrixPortal and route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import TheMatrix from './components/TheMatrix';
 import MatrixTransition from './components/MatrixTransition';
 import MatrixTerminal   from './components/MatrixTerminal';
 import MatrixPuzzle     from './components/MatrixPuzzle';
+import MatrixPortal     from './components/MatrixPortal';
 
 
 export default function App() {
@@ -26,11 +27,12 @@ export default function App() {
           <Route path="/robot-lab" element={<RobotLab />} />
           <Route path="/lego-build" element={<LegoBuildMode />} />
           <Route path="/lego-inventory" element={<LegoInventory />} />
-          <Route path="/little-alchemy" element={<LittleAlchemy />} />
+  <Route path="/little-alchemy" element={<LittleAlchemy />} />
           <Route path="/the-matrix" element={<TheMatrix />} />
           <Route path="/the-matrix"            element={<MatrixTransition />} />
   <Route path="/the-matrix/terminal"   element={<MatrixTerminal   />} />
   <Route path="/the-matrix/puzzle"     element={<MatrixPuzzle     />} />
+          <Route path="/portal" element={<MatrixPortal />} />
 
           <Route path="*" element={<Navigate to="/snack-trail" />} />
         </Routes>

--- a/src/__tests__/MatrixPortal.test.jsx
+++ b/src/__tests__/MatrixPortal.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MatrixPortal from '../components/MatrixPortal';
+
+// basic smoke test
+it('displays links to main features', () => {
+  render(
+    <MemoryRouter>
+      <MatrixPortal />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole('link', { name: /trail/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /pixel lab/i })).toBeInTheDocument();
+});

--- a/src/components/MatrixPortal.jsx
+++ b/src/components/MatrixPortal.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { navItems } from './Navigation';
+
+export default function MatrixPortal() {
+  return (
+    <div className="p-8 text-center space-y-6">
+      <h1 className="text-4xl font-bold text-purple-400">Matrix Portal</h1>
+      <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+        {navItems
+          .filter(item => item.path !== '/portal')
+          .map(({ name, path, color }) => (
+            <Link
+              key={path}
+              to={path}
+              className={`block py-2 rounded-lg font-semibold shadow-md hover:scale-105 transition-transform ${color}`}
+            >
+              {name}
+            </Link>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserPortal.jsx
+++ b/src/components/UserPortal.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- rename `UserPortal.jsx` to `MatrixPortal.jsx`
- add matrix portal component with links to other features
- map `/portal` route to the matrix portal
- add a small test for the portal links

## Testing
- `npm test --silent` *(fails: react-scripts not found)*