### PR TITLE
Update MatrixPuzzle navigation

### DIFF
--- a/src/__tests__/MatrixPuzzle.test.jsx
+++ b/src/__tests__/MatrixPuzzle.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import MatrixPuzzle from '../components/MatrixPuzzle';
+
+test('navigates to /portal after solving puzzle', async () => {
+  jest.useFakeTimers();
+  render(
+    <MemoryRouter initialEntries={["/the-matrix/puzzle"]}>
+      <Routes>
+        <Route path="/the-matrix/puzzle" element={<MatrixPuzzle />} />
+        <Route path="/portal" element={<div>Portal Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'red');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  expect(await screen.findByText(/portal page/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});

--- a/src/components/MatrixPuzzle.jsx
+++ b/src/components/MatrixPuzzle.jsx
@@ -1,13 +1,16 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function MatrixPuzzle() {
   const [answer, setAnswer] = useState('');
   const [solved, setSolved] = useState(false);
+  const navigate            = useNavigate();
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (answer.trim().toLowerCase() === 'red') {
       setSolved(true);
+      setTimeout(() => navigate('/portal'), 1000);
     }
   };
 


### PR DESCRIPTION
## Summary
- navigate to `/portal` once the Matrix puzzle is solved
- test that Matrix puzzle redirects after the correct answer

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*