### PR TITLE
Rewrite test cases for matrix flow

### DIFF
--- a/src/__tests__/MatrixTerminal.test.jsx
+++ b/src/__tests__/MatrixTerminal.test.jsx
@@ -1,28 +1,61 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import MatrixTerminal from '../components/MatrixTerminal';
+import MatrixPuzzle from '../components/MatrixPuzzle';
 
-
+function setup(initialEntries = ['/the-matrix/terminal']) {
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/the-matrix/terminal" element={<MatrixTerminal />} />
+        <Route path="/the-matrix/puzzle" element={<MatrixPuzzle />} />
+        <Route path="/portal" element={<div>Portal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
 
 async function submitCode(code) {
-
   const input = screen.getByPlaceholderText(/enter passcode/i);
   await userEvent.type(input, code);
   await userEvent.click(screen.getByRole('button', { name: /hack/i }));
 }
 
-
-});
-
 test('shows access denied when passcode is wrong', async () => {
+  setup();
   await submitCode('wrong');
   expect(screen.getByText(/access denied/i)).toBeInTheDocument();
 });
 
-test('shows quote automatically when access stored in localStorage', async () => {
+test('accepts correct passcode and moves to puzzle', async () => {
+  jest.useFakeTimers();
+  setup();
+  await submitCode('thereisnospoon');
+  expect(screen.getByText(/access granted/i)).toBeInTheDocument();
+  act(() => jest.advanceTimersByTime(2500));
+  expect(await screen.findByText(/answer this to prove you are the one/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});
+
+test('loads quote from localStorage and moves to puzzle', async () => {
+  jest.useFakeTimers();
   localStorage.setItem('matrixAccess', 'true');
-  render(<MatrixTerminal />);
-  const message = await screen.findByText(/access granted/i);
-  expect(message.textContent).toMatch(/— Naoe/);
+  setup();
+  expect(await screen.findByText(/access granted/i)).toBeInTheDocument();
+  act(() => jest.advanceTimersByTime(2500));
+  expect(await screen.findByText(/answer this to prove you are the one/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});
+
+test('solving the puzzle navigates to the portal', async () => {
+  jest.useFakeTimers();
+  setup(['/the-matrix/puzzle']);
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'red');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(await screen.findByText(/correct!/i)).toBeInTheDocument();
+  act(() => jest.advanceTimersByTime(1000));
+  expect(await screen.findByText(/portal/i)).toBeInTheDocument();
+  jest.useRealTimers();
 });

--- a/src/__tests__/TheMatrix.test.jsx
+++ b/src/__tests__/TheMatrix.test.jsx
@@ -1,31 +1,31 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import TheMatrix from '../components/TheMatrix';
-import { MemoryRouter } from 'react-router-dom';
+import MatrixTerminal from '../components/MatrixTerminal';
 
-// helper to enter the matrix by submitting a name
-async function enterMatrix(name = 'Neo') {
+function setup() {
   render(
     <MemoryRouter initialEntries={["/the-matrix"]}>
-      <TheMatrix />
+      <Routes>
+        <Route path="/the-matrix" element={<TheMatrix />} />
+        <Route path="/the-matrix/terminal" element={<MatrixTerminal />} />
+      </Routes>
     </MemoryRouter>
   );
-  const input = screen.getByPlaceholderText(/player name/i);
-  await userEvent.type(input, name);
+}
+
+async function enterName(name = 'Neo') {
+  await userEvent.type(screen.getByPlaceholderText(/player name/i), name);
   await userEvent.click(screen.getByRole('button', { name: /enter/i }));
 }
 
-test('pill buttons appear and change state when clicked', async () => {
-  await enterMatrix();
+test('choosing the red pill navigates to the terminal', async () => {
+  setup();
+  await enterName();
 
-  // pills should be visible after entering name
-  const redButton = await screen.findByRole('button', { name: /red pill/i });
-  const blueButton = screen.getByRole('button', { name: /blue pill/i });
-  expect(redButton).toBeInTheDocument();
-  expect(blueButton).toBeInTheDocument();
+  const red = await screen.findByRole('button', { name: /red pill/i });
+  await userEvent.click(red);
 
-  // clicking red pill navigates to the terminal
-  await userEvent.click(redButton);
   expect(await screen.findByText(/matrix terminal/i)).toBeInTheDocument();
 });
-


### PR DESCRIPTION
## Summary
- rewrite TheMatrix.test.jsx to check navigation to terminal
- rewrite MatrixTerminal.test.jsx with full flow tests

## Testing
- `npm test` *(fails: `react-scripts: not found`)*