### PR TITLE
[brian_m] Remove deprecated matrix effect package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.12.0",
-        "react-matrix-effect": "^1.1.0",
         "react-router-dom": "^6.21.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^3.5.0"
@@ -17864,30 +17863,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
-    },
-    "node_modules/react-matrix-effect": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-matrix-effect/-/react-matrix-effect-1.1.0.tgz",
-      "integrity": "sha512-nHHbacN2OBepvGNgN8NR5YisCRQZvzw1MqB46GvOBv5UZSp584JdwYKZKglrCZa3bY0KPdvnmiU1zq7w4AXreQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "prop-types": "^15.6.2",
-        "react": "^16.7.0"
-      }
-    },
-    "node_modules/react-matrix-effect/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
-    "react-matrix-effect": "^1.1.0",
     "react-router-dom": "^6.21.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^3.5.0"


### PR DESCRIPTION
## Summary
- remove unused `react-matrix-effect` dependency
- refresh lockfile

## Testing
- `npm install --package-lock-only`
- `npm test` *(fails: react-scripts not found)*