### PR TITLE
[brian_m] Add cleanup after each MatrixTerminal test

### DIFF
--- a/src/__tests__/MatrixTerminal.test.jsx
+++ b/src/__tests__/MatrixTerminal.test.jsx
@@ -24,6 +24,11 @@ async function submitCode(code) {
   await userEvent.click(screen.getByRole('button', { name: /hack/i }));
 }
 
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
 test('shows access denied when passcode is wrong', async () => {
   setup();
   await submitCode('wrong');


### PR DESCRIPTION
## Summary
- ensure cleanup of localStorage and timers across MatrixTerminal tests

## Testing
- `npm test` *(fails: react-scripts not found)*