### PR TITLE
[brian_m] Add RC Plane Designer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository hosts a collection of small React experiments and mini‑games. 
 - **Robot Room** – Assemble robots from hundreds of randomly generated parts. Each robot has unique stats that change as you swap components.
 - **Build Mode** – A simple LEGO building interface where you place pieces, choose colors and follow small build instructions.
 - **Inventory** – Search and filter a sample LEGO inventory to keep track of your pieces.
+- **RC Plane Designer** – Pick a style and color to craft a custom remote control plane.
 - **Alchemy** – Mix and match elements in a playful Little Alchemy‑style puzzle.
 - **The Matrix** – Enter your name, pick a pill and see how deep the rabbit hole goes. Includes a boot transition, terminal challenge.
 - **Matrix Portal** – A portal page (work in progress) intended for future connectivity between Matrix features.

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import RobotLab from './components/RobotLab';
 import LegoBuildMode from './components/LegoBuildMode';
 import LegoInventory from './components/LegoInventory';
 import LittleAlchemy from './components/LittleAlchemy';
+import RCPlaneDesigner from './components/RCPlaneDesigner';
 import TheMatrix from './components/TheMatrix';
 import MatrixTransition from './components/MatrixTransition';
 import MatrixTerminal   from './components/MatrixTerminal';
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="/robot-lab" element={<RobotLab />} />
           <Route path="/lego-build" element={<LegoBuildMode />} />
           <Route path="/lego-inventory" element={<LegoInventory />} />
+          <Route path="/rc-plane" element={<RCPlaneDesigner />} />
   <Route path="/little-alchemy" element={<LittleAlchemy />} />
           <Route path="/the-matrix" element={<TheMatrix />} />
           <Route path="/the-matrix/terminal"   element={<MatrixTerminal   />} />

--- a/src/__tests__/RCPlaneDesigner.test.jsx
+++ b/src/__tests__/RCPlaneDesigner.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import RCPlaneDesigner from '../components/RCPlaneDesigner';
+import Navigation from '../components/Navigation';
+
+function setup(path = '/rc-plane') {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Navigation />
+      <Routes>
+        <Route path="/rc-plane" element={<RCPlaneDesigner />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test('renders RC Plane Designer heading', () => {
+  setup();
+  expect(screen.getByRole('heading', { name: /rc plane designer/i })).toBeInTheDocument();
+});
+
+test('navigation has RC Plane link', () => {
+  setup();
+  expect(screen.getByRole('link', { name: /rc plane/i })).toBeInTheDocument();
+});

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -8,7 +8,8 @@ import {
   FaCube,
   FaBox,
   FaFlask,
-  FaCodeBranch
+  FaCodeBranch,
+  FaPaperPlane
 } from 'react-icons/fa';
 
 export const navItems = [
@@ -23,6 +24,7 @@ export const navItems = [
   { name: 'Build Mode', path: '/lego-build', color: 'bg-red-500', icon: FaCube },
   { name: 'Inventory', path: '/lego-inventory', color: 'bg-yellow-600', icon: FaBox },
   { name: 'Alchemy', path: '/little-alchemy', color: 'bg-cyan-500', icon: FaFlask },
+  { name: 'RC Plane', path: '/rc-plane', color: 'bg-cyan-400', icon: FaPaperPlane },
   {
     name: 'The Matrix',
     path: '/the-matrix',

--- a/src/components/RCPlaneDesigner.jsx
+++ b/src/components/RCPlaneDesigner.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { FaPaperPlane } from 'react-icons/fa';
+
+const planeTypes = [
+  { id: 'glider', name: 'Glider' },
+  { id: 'stunt', name: 'Stunt' },
+  { id: 'speed', name: 'Speed' }
+];
+
+const colors = [
+  { id: 'red', name: 'Red', value: '#f87171' },
+  { id: 'blue', name: 'Blue', value: '#60a5fa' },
+  { id: 'green', name: 'Green', value: '#34d399' }
+];
+
+export default function RCPlaneDesigner() {
+  const [type, setType] = useState('glider');
+  const [color, setColor] = useState(colors[0].value);
+
+  return (
+    <div className="p-4 space-y-6 flex flex-col items-center">
+      <h1 className="text-3xl font-bold text-cyan-300 flex items-center gap-2">
+        <FaPaperPlane /> RC Plane Designer
+      </h1>
+      <div className="bg-gray-800 p-4 rounded-xl space-y-4 w-full max-w-sm">
+        <div>
+          <h2 className="font-semibold mb-2">1. Choose a plane type</h2>
+          <div className="flex gap-2">
+            {planeTypes.map(p => (
+              <button
+                key={p.id}
+                onClick={() => setType(p.id)}
+                className={`flex-1 py-1 rounded-lg text-sm ${
+                  type === p.id ? 'bg-cyan-600' : 'bg-gray-700 hover:bg-gray-600'
+                }`}
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">2. Pick a color</h2>
+          <div className="flex gap-2">
+            {colors.map(c => (
+              <button
+                key={c.id}
+                onClick={() => setColor(c.value)}
+                className={`w-8 h-8 rounded-full border-2 ${
+                  color === c.value ? 'border-white' : 'border-gray-700'
+                }`}
+                style={{ backgroundColor: c.value }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="w-40 h-40 bg-gray-800 rounded-xl flex items-center justify-center" style={{ backgroundColor: color }}>
+        <FaPaperPlane className="text-6xl" />
+      </div>
+      <p className="text-sm text-gray-400 text-center max-w-xs">
+        This is a simple starting point. Choose a type and color for your plane. More build options will go here soon!
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add **RC Plane Designer** component for picking a plane type and color
- expose new page through navigation and routing
- document feature in README
- add basic tests for RC Plane Designer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*