### PR TITLE
[brian_m] add updates tab and remove alchemy ticket

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import TheMatrix from './components/TheMatrix';
 import MatrixTransition from './components/MatrixTransition';
 import MatrixTerminal   from './components/MatrixTerminal';
 import MatrixPortal     from './components/MatrixPortal';
+import Updates from './components/Updates';
 
 
 export default function App() {
@@ -31,7 +32,8 @@ export default function App() {
           <Route path="/lego-build" element={<LegoBuildMode />} />
           <Route path="/lego-inventory" element={<LegoInventory />} />
           <Route path="/rc-plane" element={<RCPlaneDesigner />} />
-  <Route path="/little-alchemy" element={<LittleAlchemy />} />
+          <Route path="/little-alchemy" element={<LittleAlchemy />} />
+          <Route path="/updates" element={<Updates />} />
           <Route path="/the-matrix" element={<TheMatrix />} />
           <Route path="/the-matrix/terminal"   element={<MatrixTerminal   />} />
           <Route path="/the-matrix/transition" element={<MatrixTransition />} />

--- a/src/components/LittleAlchemy.jsx
+++ b/src/components/LittleAlchemy.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  FaFire, FaWater, FaWind, FaMountain, FaLeaf, FaPlus, 
+import {
+  FaFire, FaWater, FaWind, FaMountain, FaLeaf,
   FaCloud, FaSun, FaMoon, FaTree, FaStar, FaSpider,
-  FaDragon, FaSnowflake, FaTimes, FaQuestionCircle, FaChevronDown
+  FaDragon, FaSnowflake, FaTimes, FaQuestionCircle
 } from 'react-icons/fa';
 
 const STORAGE_KEY = 'littleAlchemyDiscoveries';
@@ -21,23 +21,6 @@ const CATEGORIES = [
   'Abstract'
 ];
 
-// Add announcement system
-const ANNOUNCEMENTS = [
-  {
-    id: 'bug-fix-1',
-    title: 'Bug Hunter Award! 🏆',
-    message: 'Chris discovered duplicate combinations in the game! Thanks to his sharp eyes, we fixed the issue and now have exactly 45 unique combinations.',
-    type: 'achievement',
-    date: new Date().toISOString()
-  },
-  {
-    id: 'sports-update-1',
-    title: 'Football Frenzy! 🏈',
-    message: '10 new football elements added! Can you find the secret "Jets Stink" combo? (Easter egg for Chris!)',
-    type: 'update',
-    date: new Date().toISOString()
-  }
-];
 
 const LittleAlchemy = () => {
   const [workspace, setWorkspace] = useState(() => {
@@ -53,8 +36,6 @@ const LittleAlchemy = () => {
   const [notification, setNotification] = useState(null);
   const [showCheatList, setShowCheatList] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState(null);
-  const [announcements, setAnnouncements] = useState(ANNOUNCEMENTS);
-  const [currentAnnouncement, setCurrentAnnouncement] = useState(0);
 
   const baseElements = [
     { id: 'fire', name: 'Fire', icon: FaFire, color: 'text-red-500' },
@@ -171,13 +152,6 @@ const LittleAlchemy = () => {
     localStorage.setItem(WORKSPACE_KEY, JSON.stringify(workspace));
   }, [workspace]);
 
-  // Rotate announcements
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCurrentAnnouncement(prev => (prev + 1) % announcements.length);
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [announcements.length]);
 
   const showNotification = (discovery) => {
     setNotification(discovery);
@@ -250,23 +224,7 @@ const LittleAlchemy = () => {
 
   return (
     <div className="flex flex-col space-y-6">
-      {/* Announcement Bar */}
-      <div className="fixed top-0 left-0 right-0 bg-gradient-to-r from-purple-600 via-pink-500 to-red-500 text-white py-2 overflow-hidden z-50">
-        <div className="animate-marquee whitespace-nowrap">
-          {announcements.map((announcement, index) => (
-            <div
-              key={announcement.id}
-              className={`inline-block mx-4 transition-opacity duration-500 ${
-                index === currentAnnouncement ? 'opacity-100' : 'opacity-0'
-              }`}
-            >
-              <span className="font-bold">{announcement.title}</span>
-              <span className="mx-2">•</span>
-              <span>{announcement.message}</span>
-            </div>
-          ))}
-        </div>
-      </div>
+
 
       {/* Notification */}
       {notification && (

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -9,7 +9,8 @@ import {
   FaBox,
   FaFlask,
   FaCodeBranch,
-  FaPaperPlane
+  FaPaperPlane,
+  FaBug
 } from 'react-icons/fa';
 
 export const navItems = [
@@ -25,6 +26,7 @@ export const navItems = [
   { name: 'Inventory', path: '/lego-inventory', color: 'bg-yellow-600', icon: FaBox },
   { name: 'Alchemy', path: '/little-alchemy', color: 'bg-cyan-500', icon: FaFlask },
   { name: 'RC Plane', path: '/rc-plane', color: 'bg-cyan-400', icon: FaPaperPlane },
+  { name: 'Updates', path: '/updates', color: 'bg-indigo-500', icon: FaBug },
   {
     name: 'The Matrix',
     path: '/the-matrix',

--- a/src/components/Updates.jsx
+++ b/src/components/Updates.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { FaBug } from 'react-icons/fa';
+import { ANNOUNCEMENTS } from '../data/announcements';
+
+export default function Updates() {
+  return (
+    <div className="p-6 flex flex-col space-y-6">
+      <h1 className="text-3xl font-bold text-indigo-400 flex items-center gap-3">
+        <FaBug /> Updates
+      </h1>
+      <div className="space-y-4">
+        {ANNOUNCEMENTS.map((item) => (
+          <div key={item.id} className="bg-gray-800 p-4 rounded-lg shadow">
+            <div className="font-bold mb-1">{item.title}</div>
+            <p className="text-gray-300 text-sm">{item.message}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/announcements.js
+++ b/src/data/announcements.js
@@ -1,0 +1,16 @@
+export const ANNOUNCEMENTS = [
+  {
+    id: 'bug-fix-1',
+    title: 'Bug Hunter Award! 🏆',
+    message: 'Chris discovered duplicate combinations in the game! Thanks to his sharp eyes, we fixed the issue and now have exactly 45 unique combinations.',
+    type: 'achievement',
+    date: new Date().toISOString(),
+  },
+  {
+    id: 'sports-update-1',
+    title: 'Football Frenzy! 🏈',
+    message: '10 new football elements added! Can you find the secret "Jets Stink" combo? (Easter egg for Chris!)',
+    type: 'update',
+    date: new Date().toISOString(),
+  },
+];


### PR DESCRIPTION
## Summary
- remove in-component announcements from Little Alchemy
- add new Updates page that lists announcements
- hook up Updates page in global navigation and routing
- extract announcements data

## Testing
- `npm test` *(fails: react-scripts not found)*