### PR TITLE
[brian_m] Add MatrixV1 journey components and routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,13 @@ import MatrixTerminal   from './components/MatrixTerminal';
 import MatrixPortal     from './components/MatrixPortal';
 import Updates from './components/Updates';
 
+// Matrix v1 pages
+import Entry from './pages/matrix-v1/Entry';
+import Terminal from './pages/matrix-v1/Terminal';
+import Transition from './pages/matrix-v1/Transition';
+import Puzzle from './pages/matrix-v1/Puzzle';
+import Portal from './pages/matrix-v1/Portal';
+
 
 export default function App() {
   return (
@@ -40,6 +47,13 @@ export default function App() {
           <Route path="/the-matrix/terminal"   element={<MatrixTerminal   />} />
           <Route path="/the-matrix/transition" element={<MatrixTransition />} />
           <Route path="/the-matrix/portal"     element={<MatrixPortal     />} />
+
+          {/* Matrix v1 journey */}
+          <Route path="/matrix-v1" element={<Entry />} />
+          <Route path="/matrix-v1/terminal" element={<Terminal />} />
+          <Route path="/matrix-v1/transition" element={<Transition />} />
+          <Route path="/matrix-v1/puzzle" element={<Puzzle />} />
+          <Route path="/matrix-v1/portal" element={<Portal />} />
 
           <Route path="*" element={<Navigate to="/snack-trail" />} />
         </Routes>

--- a/src/__tests__/MatrixV1Terminal.test.jsx
+++ b/src/__tests__/MatrixV1Terminal.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Terminal from '../pages/matrix-v1/Terminal';
+
+function setup(initialEntries = ['/matrix-v1/terminal']) {
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/matrix-v1/terminal" element={<Terminal />} />
+        <Route path="/matrix-v1/transition" element={<div>Transition</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+async function submit(code) {
+  const input = screen.getByPlaceholderText(/enter passcode/i);
+  await userEvent.type(input, code);
+  await userEvent.click(screen.getByRole('button', { name: /hack/i }));
+}
+
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+test('shows access denied with wrong code', async () => {
+  setup();
+  await submit('wrong');
+  expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+});
+
+test('accepts code and navigates to transition', async () => {
+  jest.useFakeTimers();
+  setup();
+  await submit('thereisnospoon');
+  expect(screen.getByText(/access granted/i)).toBeInTheDocument();
+  act(() => jest.advanceTimersByTime(2500));
+  expect(await screen.findByText(/transition/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});
+

--- a/src/__tests__/MatrixV1Transition.test.jsx
+++ b/src/__tests__/MatrixV1Transition.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Transition from '../pages/matrix-v1/Transition';
+
+function setup(initialEntries = ['/matrix-v1/transition']) {
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/matrix-v1/transition" element={<Transition />} />
+        <Route path="/matrix-v1/puzzle" element={<div>Puzzle</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test('auto-navigates to puzzle after timeout', async () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  expect(await screen.findByText(/puzzle/i)).toBeInTheDocument();
+  jest.useRealTimers();
+});

--- a/src/pages/matrix-v1/Entry.jsx
+++ b/src/pages/matrix-v1/Entry.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import Rain from './components/Rain';
+
+export default function Entry() {
+  const [name, setName] = useState(() => localStorage.getItem('matrixV1Name') || '');
+  const [entered, setEntered] = useState(!!name);
+  const navigate = useNavigate();
+  const [intro] = useTypewriterEffect('Welcome to the Matrix', 50);
+  const [prompt] = useTypewriterEffect('Enter your name to begin:', 50);
+
+  const submit = (e) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed) {
+      localStorage.setItem('matrixV1Name', trimmed);
+      setEntered(true);
+    }
+  };
+
+  const red = () => navigate('/matrix-v1/terminal', { state: { name } });
+  const blue = () => navigate('/');
+
+  return (
+    <div className="flex flex-col items-center justify-center py-20 space-y-6 min-h-screen relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <Rain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6 text-center">
+        {!entered && (
+          <>
+            <h1 className="text-4xl font-bold text-green-500 font-mono">{intro}</h1>
+            <p className="text-xl">{prompt}</p>
+            <form onSubmit={submit} className="flex space-x-2">
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Player Name"
+                className="px-4 py-2 rounded bg-black border border-green-700 text-green-500 placeholder-green-700 focus:outline-none"
+              />
+              <button type="submit" className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600">
+                Enter
+              </button>
+            </form>
+          </>
+        )}
+        {entered && (
+          <>
+            <p className="text-lg">Hello, {name}. Choose your destiny.</p>
+            <div className="flex space-x-4">
+              <button onClick={red} className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500">
+                Red Pill
+              </button>
+              <button onClick={blue} className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500">
+                Blue Pill
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/Portal.jsx
+++ b/src/pages/matrix-v1/Portal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { navItems } from '../../components/Navigation';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import { NAOE_QUOTES } from '../../data/naoeQuotes';
+import FlowDrawer from './components/FlowDrawer';
+import Rain from './components/Rain';
+
+export default function Portal() {
+  const name = localStorage.getItem('matrixV1Name') || 'Traveler';
+  const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
+  const [welcomeText] = useTypewriterEffect(`Welcome, ${name}`, 50);
+  const [quoteText] = useTypewriterEffect(`${q.text} — ${q.attribution}`, 50);
+
+  return (
+    <div className="p-8 text-center space-y-6 min-h-screen relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <Rain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6">
+        <h1 className="text-4xl font-bold text-purple-400">{welcomeText}</h1>
+        <p className="text-lg text-center max-w-md">{quoteText}</p>
+        <p className="text-sm text-gray-300">Select a destination</p>
+        <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+          {navItems
+            .filter((item) => item.path !== '/the-matrix')
+            .map(({ name, path, color, icon: Icon }) => (
+              <Link
+                key={path}
+                to={path}
+                className={`flex flex-col items-center py-4 rounded-lg font-semibold shadow-md hover:scale-105 transition-transform ${color}`}
+              >
+                {Icon && <Icon className="mb-1 text-xl" />}
+                {name}
+              </Link>
+            ))}
+        </div>
+        <FlowDrawer />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/Puzzle.jsx
+++ b/src/pages/matrix-v1/Puzzle.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { NAOE_QUOTES } from '../../data/naoeQuotes';
+import Rain from './components/Rain';
+
+export default function Puzzle() {
+  const navigate = useNavigate();
+  const [answer, setAnswer] = useState('');
+  const [response, setResponse] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const clean = answer.trim().toLowerCase();
+    if (clean === 'yes' || clean === 'y') {
+      const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
+      setResponse(`${q.text} — ${q.attribution}`);
+    } else {
+      setResponse('*** SYSTEM GLITCH ***');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-6 relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <Rain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6">
+        <h1 className="text-2xl font-bold">Do you believe in fate?</h1>
+        <form onSubmit={handleSubmit} className="flex space-x-2">
+          <input
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            className="px-4 py-2 rounded bg-black border border-green-700 text-green-500 placeholder-green-700 focus:outline-none"
+            placeholder="your answer"
+          />
+          <button className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600">Submit</button>
+        </form>
+        {response && <p className="text-lg text-center max-w-md">{response}</p>}
+        {response && (
+          <button onClick={() => navigate('/matrix-v1/portal')} className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-500">
+            Continue
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/Terminal.jsx
+++ b/src/pages/matrix-v1/Terminal.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import { NAOE_QUOTES } from '../../data/naoeQuotes';
+import Rain from './components/Rain';
+
+export default function Terminal() {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const name = state?.name || localStorage.getItem('matrixV1Name');
+  const [code, setCode] = useState('');
+  const [msg, setMsg] = useState('');
+  const [ok, setOk] = useState(false);
+  const secret = 'thereisnospoon';
+  const [typedMsg] = useTypewriterEffect(msg, 50);
+
+  useEffect(() => {
+    if (localStorage.getItem('matrixV1Access') === 'true') {
+      grant();
+    }
+  }, []);
+
+  const grant = () => {
+    const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
+    setMsg(`Access granted. ${q.text} — ${q.attribution}`);
+    setOk(true);
+    localStorage.setItem('matrixV1Access', 'true');
+    setTimeout(() => navigate('/matrix-v1/transition', { state: { name } }), 2500);
+  };
+
+  const submit = (e) => {
+    e.preventDefault();
+    code.trim().toLowerCase() === secret
+      ? grant()
+      : setMsg('Access Denied');
+  };
+
+  const logout = () => {
+    localStorage.removeItem('matrixV1Access');
+    setOk(false);
+    setCode('');
+    setMsg('');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-6 relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <Rain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6 w-full">
+        <h1 className="text-4xl font-bold">Matrix Terminal</h1>
+        {!ok && (
+          <form onSubmit={submit} className="flex space-x-2">
+            <input
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="enter passcode"
+              className="px-4 py-2 rounded bg-black border border-green-700 text-green-500 placeholder-green-700 focus:outline-none"
+            />
+            <button className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600">
+              Hack
+            </button>
+          </form>
+        )}
+        {msg && <p className="text-lg text-center max-w-md">{typedMsg}</p>}
+        {ok && (
+          <button onClick={logout} className="text-sm underline text-green-400">
+            log out
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/Transition.jsx
+++ b/src/pages/matrix-v1/Transition.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import { NAOE_QUOTES } from '../../data/naoeQuotes';
+import Rain from './components/Rain';
+
+export default function Transition() {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const name = state?.name || localStorage.getItem('matrixV1Name');
+  const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
+  const [bootText] = useTypewriterEffect('Booting simulated reality...', 50);
+  const [quoteText] = useTypewriterEffect(`${q.text} — ${q.attribution}`, 50);
+
+  useEffect(() => {
+    const t = setTimeout(() => navigate('/matrix-v1/puzzle', { state: { name } }), 3000);
+    return () => clearTimeout(t);
+  }, [navigate, name]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono space-y-6 relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <Rain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6">
+        <p className="text-xl animate-pulse">{bootText}</p>
+        <p className="text-lg text-center max-w-md">{quoteText}</p>
+        <div className="w-64 h-2 bg-green-900 overflow-hidden rounded">
+          <div className="h-full bg-green-500 animate-progress" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/components/FlowDrawer.jsx
+++ b/src/pages/matrix-v1/components/FlowDrawer.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect, useRef } from 'react';
+import mermaid from 'mermaid';
+
+export default function MatrixFlowDrawer() {
+  const [open, setOpen] = useState(false);
+  const [diagram, setDiagram] = useState('');
+  const diagramRef = useRef(null);
+
+  useEffect(() => {
+    fetch(process.env.PUBLIC_URL + '/matrix-flow.mmd')
+      .then(res => res.text())
+      .then(setDiagram)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (open && diagram && diagramRef.current) {
+      // Render the mermaid diagram into the div
+      mermaid.initialize({ startOnLoad: false });
+      mermaid.render('matrixFlow', diagram, (svgCode) => {
+        diagramRef.current.innerHTML = svgCode;
+      });
+    }
+  }, [open, diagram]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 text-sm">
+      <button
+        onClick={() => setOpen(!open)}
+        className="bg-white/30 backdrop-blur-md p-2 rounded shadow-md"
+        aria-label="Matrix flow diagram"
+      >
+        📈
+      </button>
+
+      {open && (
+        <div className="fixed bottom-16 right-4 w-80 bg-white text-black rounded shadow-lg max-h-[70vh] overflow-auto">
+          <div className="flex justify-between items-center p-2 border-b">
+            <h2 className="font-bold">Matrix Flow</h2>
+            <button onClick={() => setOpen(false)} className="text-xl font-bold" aria-label="Close">×</button>
+          </div>
+          <div className="p-2">
+            <div ref={diagramRef} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/components/Rain.jsx
+++ b/src/pages/matrix-v1/components/Rain.jsx
@@ -1,0 +1,73 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function MatrixRain({ style = {}, zIndex = 0 }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let fontSize = 18;
+    let columns = Math.floor(width / fontSize);
+    let drops = Array(columns).fill(1);
+    const chars = 'アァカサタナハマヤャラワガザダバパイィキシチニヒミリヰギジヂビピウゥクスツヌフムユュルグズヅブプエェケセテネヘメレヱゲゼデベペオォコソトノホモヨョロヲゴゾドボポヴッンABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+    function resize() {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
+      columns = Math.floor(width / fontSize);
+      drops = Array(columns).fill(1);
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+
+    function draw() {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.font = fontSize + 'px monospace';
+      ctx.fillStyle = '#00FF41';
+      for (let i = 0; i < drops.length; i++) {
+        const text = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+        if (drops[i] * fontSize > height && Math.random() > 0.975) {
+          drops[i] = 0;
+        }
+        drops[i]++;
+      }
+    }
+
+    let animationId;
+    function animate() {
+      draw();
+      animationId = requestAnimationFrame(animate);
+    }
+    animate();
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      cancelAnimationFrame(animationId);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        zIndex,
+        ...style,
+      }}
+      width={window.innerWidth}
+      height={window.innerHeight}
+      aria-hidden="true"
+    />
+  );
+} 


### PR DESCRIPTION
## Summary
- scaffold Matrix V1 user journey under `/matrix-v1/*`
- create Entry, Terminal, Transition, Puzzle, and Portal pages
- add FlowDrawer and Rain components for the new journey
- wire up routes in `App.js`
- add basic tests for Terminal and Transition flows

## Testing
- `npm test --silent` *(fails: react-scripts not found)*