### PR TITLE
[brian_m] extend Matrix v1 flow

### DIFF
--- a/src/__tests__/MatrixV1Puzzle.test.jsx
+++ b/src/__tests__/MatrixV1Puzzle.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Puzzle from '../pages/matrix-v1/Puzzle';
+
+function setup() {
+  localStorage.setItem('matrixV1Access', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/puzzle']}>
+      <Routes>
+        <Route path="/matrix-v1/puzzle" element={<Puzzle />} />
+        <Route path="/matrix-v1/portal" element={<div>Portal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+test('responds with a quote to thoughtful answer', async () => {
+  setup();
+  const input = screen.getByPlaceholderText(/your answer/i);
+  await userEvent.type(input, 'no, I make my own choice');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(screen.getByText(/naoe/i)).toBeInTheDocument();
+});
+
+test('responds with glitch to silly answer', async () => {
+  setup();
+  const input = screen.getByPlaceholderText(/your answer/i);
+  await userEvent.type(input, 'pizza time');
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(screen.getByText(/system glitch/i)).toBeInTheDocument();
+});
+

--- a/src/__tests__/MatrixV1Transition.test.jsx
+++ b/src/__tests__/MatrixV1Transition.test.jsx
@@ -15,6 +15,7 @@ function setup(initialEntries = ['/matrix-v1/transition']) {
 
 test('auto-navigates to puzzle after timeout', async () => {
   jest.useFakeTimers();
+  localStorage.setItem('matrixV1Access', 'true');
   setup();
   act(() => {
     jest.advanceTimersByTime(3000);

--- a/src/index.css
+++ b/src/index.css
@@ -20,4 +20,18 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
-} 
+}
+
+@layer utilities {
+  @keyframes progress {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  .animate-progress {
+    animation: progress 3s linear forwards;
+  }
+}

--- a/src/pages/matrix-v1/Portal.jsx
+++ b/src/pages/matrix-v1/Portal.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { navItems } from '../../components/Navigation';
 import useTypewriterEffect from '../../components/useTypewriterEffect';
 import { NAOE_QUOTES } from '../../data/naoeQuotes';
@@ -7,10 +7,17 @@ import FlowDrawer from './components/FlowDrawer';
 import Rain from './components/Rain';
 
 export default function Portal() {
+  const navigate = useNavigate();
   const name = localStorage.getItem('matrixV1Name') || 'Traveler';
   const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
-  const [welcomeText] = useTypewriterEffect(`Welcome, ${name}`, 50);
+  const [welcomeText] = useTypewriterEffect(`Welcome back, ${name}`, 50);
   const [quoteText] = useTypewriterEffect(`${q.text} — ${q.attribution}`, 50);
+
+  useEffect(() => {
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
 
   return (
     <div className="p-8 text-center space-y-6 min-h-screen relative overflow-hidden">

--- a/src/pages/matrix-v1/Puzzle.jsx
+++ b/src/pages/matrix-v1/Puzzle.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NAOE_QUOTES } from '../../data/naoeQuotes';
 import Rain from './components/Rain';
@@ -8,14 +8,25 @@ export default function Puzzle() {
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
 
+  useEffect(() => {
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     const clean = answer.trim().toLowerCase();
-    if (clean === 'yes' || clean === 'y') {
+    const wiseWords = ['no', 'choice', 'control'];
+    const sillyWords = ['pizza', 'cat', 'dog', 'burger'];
+
+    if (sillyWords.some((w) => clean.includes(w))) {
+      setResponse('*** SYSTEM GLITCH ***');
+    } else if (wiseWords.some((w) => clean.includes(w))) {
       const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
       setResponse(`${q.text} — ${q.attribution}`);
     } else {
-      setResponse('*** SYSTEM GLITCH ***');
+      setResponse('Interesting...');
     }
   };
 

--- a/src/pages/matrix-v1/Transition.jsx
+++ b/src/pages/matrix-v1/Transition.jsx
@@ -13,7 +13,14 @@ export default function Transition() {
   const [quoteText] = useTypewriterEffect(`${q.text} — ${q.attribution}`, 50);
 
   useEffect(() => {
-    const t = setTimeout(() => navigate('/matrix-v1/puzzle', { state: { name } }), 3000);
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+      return;
+    }
+    const t = setTimeout(
+      () => navigate('/matrix-v1/puzzle', { state: { name } }),
+      3000
+    );
     return () => clearTimeout(t);
   }, [navigate, name]);
 


### PR DESCRIPTION
## Summary
- gate access for Matrix v1 pages using `matrixV1Access`
- build puzzle logic and portal welcome
- add progress animation utility
- expand tests for the new flow

## Testing
- `npm test --silent` *(fails: react-scripts not found)*