### PR TITLE
[brian_m] Add NPC narrative layer to MatrixV1

### DIFF
--- a/src/__tests__/MatrixV1Puzzle.test.jsx
+++ b/src/__tests__/MatrixV1Puzzle.test.jsx
@@ -21,6 +21,9 @@ test('responds with a quote to thoughtful answer', async () => {
   await userEvent.type(input, 'no, I make my own choice');
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(screen.getByText(/naoe/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(/you've got the gift, but it looks like you're waiting/i)
+  ).toBeInTheDocument();
 });
 
 test('responds with glitch to silly answer', async () => {
@@ -29,5 +32,6 @@ test('responds with glitch to silly answer', async () => {
   await userEvent.type(input, 'pizza time');
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(screen.getByText(/system glitch/i)).toBeInTheDocument();
+  expect(screen.getByText(/you're cute. now get serious./i)).toBeInTheDocument();
 });
 

--- a/src/__tests__/MatrixV1Terminal.test.jsx
+++ b/src/__tests__/MatrixV1Terminal.test.jsx
@@ -41,3 +41,12 @@ test('accepts code and navigates to transition', async () => {
   jest.useRealTimers();
 });
 
+test('shows agent after three failed attempts', async () => {
+  setup();
+  await submit('wrong1');
+  await submit('wrong2');
+  await submit('wrong3');
+  expect(screen.getByText(/agent echo/i)).toBeInTheDocument();
+  expect(screen.getByText(/not supposed to be here/i)).toBeInTheDocument();
+});
+

--- a/src/pages/matrix-v1/Entry.jsx
+++ b/src/pages/matrix-v1/Entry.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useTypewriterEffect from '../../components/useTypewriterEffect';
 import Rain from './components/Rain';
+import NPC from './components/NPC';
 
 export default function Entry() {
   const [name, setName] = useState(() => localStorage.getItem('matrixV1Name') || '');
@@ -47,6 +48,12 @@ export default function Entry() {
         )}
         {entered && (
           <>
+            <NPC
+              name="Morpheus"
+              quote={`I've been waiting for you, ${name}. You've felt it, haven't you?`}
+              style="mentor"
+              className="mb-2"
+            />
             <p className="text-lg">Hello, {name}. Choose your destiny.</p>
             <div className="flex space-x-4">
               <button onClick={red} className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-500">

--- a/src/pages/matrix-v1/Portal.jsx
+++ b/src/pages/matrix-v1/Portal.jsx
@@ -5,6 +5,7 @@ import useTypewriterEffect from '../../components/useTypewriterEffect';
 import { NAOE_QUOTES } from '../../data/naoeQuotes';
 import FlowDrawer from './components/FlowDrawer';
 import Rain from './components/Rain';
+import NPC from './components/NPC';
 
 export default function Portal() {
   const navigate = useNavigate();
@@ -43,6 +44,11 @@ export default function Portal() {
             ))}
         </div>
         <FlowDrawer />
+        <NPC
+          name="Morpheus"
+          quote="Where you go from here is a choice I leave to you."
+          style="mentor"
+        />
       </div>
     </div>
   );

--- a/src/pages/matrix-v1/Puzzle.jsx
+++ b/src/pages/matrix-v1/Puzzle.jsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NAOE_QUOTES } from '../../data/naoeQuotes';
 import Rain from './components/Rain';
+import NPC from './components/NPC';
 
 export default function Puzzle() {
   const navigate = useNavigate();
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
+  const [npc, setNpc] = useState(null);
 
   useEffect(() => {
     if (localStorage.getItem('matrixV1Access') !== 'true') {
@@ -22,11 +24,22 @@ export default function Puzzle() {
 
     if (sillyWords.some((w) => clean.includes(w))) {
       setResponse('*** SYSTEM GLITCH ***');
+      setNpc({
+        name: 'Oracle',
+        quote: "You're cute. Now get serious.",
+        style: 'oracle',
+      });
     } else if (wiseWords.some((w) => clean.includes(w))) {
       const q = NAOE_QUOTES[Math.floor(Math.random() * NAOE_QUOTES.length)];
       setResponse(`${q.text} — ${q.attribution}`);
+      setNpc({
+        name: 'Oracle',
+        quote: "You've got the gift, but it looks like you're waiting for something...",
+        style: 'oracle',
+      });
     } else {
       setResponse('Interesting...');
+      setNpc(null);
     }
   };
 
@@ -47,6 +60,9 @@ export default function Puzzle() {
           <button className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600">Submit</button>
         </form>
         {response && <p className="text-lg text-center max-w-md">{response}</p>}
+        {npc && (
+          <NPC name={npc.name} quote={npc.quote} style={npc.style} />
+        )}
         {response && (
           <button onClick={() => navigate('/matrix-v1/portal')} className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-500">
             Continue

--- a/src/pages/matrix-v1/Terminal.jsx
+++ b/src/pages/matrix-v1/Terminal.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import useTypewriterEffect from '../../components/useTypewriterEffect';
 import { NAOE_QUOTES } from '../../data/naoeQuotes';
 import Rain from './components/Rain';
+import NPC from './components/NPC';
 
 export default function Terminal() {
   const navigate = useNavigate();
@@ -11,6 +12,7 @@ export default function Terminal() {
   const [code, setCode] = useState('');
   const [msg, setMsg] = useState('');
   const [ok, setOk] = useState(false);
+  const [attempts, setAttempts] = useState(0);
   const secret = 'thereisnospoon';
   const [typedMsg] = useTypewriterEffect(msg, 50);
 
@@ -30,9 +32,12 @@ export default function Terminal() {
 
   const submit = (e) => {
     e.preventDefault();
-    code.trim().toLowerCase() === secret
-      ? grant()
-      : setMsg('Access Denied');
+    if (code.trim().toLowerCase() === secret) {
+      grant();
+    } else {
+      setMsg('Access Denied');
+      setAttempts((a) => a + 1);
+    }
   };
 
   const logout = () => {
@@ -63,6 +68,13 @@ export default function Terminal() {
           </form>
         )}
         {msg && <p className="text-lg text-center max-w-md">{typedMsg}</p>}
+        {!ok && attempts >= 3 && (
+          <NPC
+            name="Agent Echo"
+            quote="You're not supposed to be here."
+            style="agent"
+          />
+        )}
         {ok && (
           <button onClick={logout} className="text-sm underline text-green-400">
             log out

--- a/src/pages/matrix-v1/components/NPC.jsx
+++ b/src/pages/matrix-v1/components/NPC.jsx
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from 'react';
+
+export default function NPC({ name, quote, style = 'mentor', className = '' }) {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    setShow(true);
+  }, []);
+
+  let variant = '';
+  if (style === 'oracle') {
+    variant = 'border-purple-400 text-purple-200 italic shadow-[0_0_8px_#a855f7]';
+  } else if (style === 'agent') {
+    variant = 'border-red-600 text-red-400 animate-pulse';
+  } else {
+    variant = 'border-green-400 text-green-200 font-bold';
+  }
+
+  return (
+    <div
+      className={`transition-opacity duration-700 ${show ? 'opacity-100' : 'opacity-0'} ${className}`}
+    >
+      <div className="mb-1 text-sm uppercase tracking-wider">{name}</div>
+      <div className={`bg-black/60 backdrop-blur-md border p-3 rounded-lg ${variant}`}>{quote}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `NPC` component with style variants
- drop NPC lines into MatrixV1 pages
- show agent NPC after repeated terminal failures
- display oracle NPC reactions on puzzle answers
- add final Morpheus NPC in portal
- update tests for new NPC interactions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*