### PR TITLE
[brian_m] fix breadcrumbs overlap with sticky positioning

### DIFF
--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -14,7 +14,7 @@ export default function Breadcrumbs() {
   });
 
   return (
-    <nav className="fixed top-14 left-0 right-0 z-40 px-4 py-2 bg-white/70 backdrop-blur-md shadow rounded-b-lg">
+    <nav className="sticky top-14 z-40 w-full px-4 py-2 bg-white/70 backdrop-blur-md shadow rounded-b-lg">
       <ol className="flex text-sm text-gray-700 space-x-2">
         <li>
           <Link to="/" className="hover:underline">Home</Link>


### PR DESCRIPTION
## Summary
- switch breadcrumb nav from `fixed` to `sticky` so content isn't overlapped

## Testing
- `npm test` *(fails: `react-scripts: not found`)*