### PR TITLE
[brian_m] Improve Snack Trail UX

### DIFF
--- a/src/components/SnackTrail.jsx
+++ b/src/components/SnackTrail.jsx
@@ -33,6 +33,18 @@ export default function SnackTrail() {
   const [customizing, setCustomizing] = useState(false);
   const [crewInputs, setCrewInputs] = useState(() => timeline[0].crew.map(member => ({ name: member.name, avatar: member.avatar || DEFAULT_AVATARS[0] })));
 
+  const restartGame = () => {
+    const freshCrew = loadSavedCrew();
+    setTimeline([{ crew: freshCrew, log: [] }]);
+    setCurrentDay(0);
+    setArcadeMode(false);
+    setWinner(null);
+    setGameOver(null);
+    setTitle('');
+    setCrewInputs(freshCrew.map(member => ({ name: member.name, avatar: member.avatar || DEFAULT_AVATARS[0] })));
+    setCustomizing(false);
+  };
+
   const crew = timeline[currentDay].crew;
   const log = timeline.flatMap(day => day.log).slice(0, 8);
 
@@ -203,13 +215,13 @@ export default function SnackTrail() {
         <VictoryScreen
           crew={crew}
           winner={winner}
-          onRestart={() => window.location.reload()}
+          onRestart={restartGame}
         />
       ) : gameOver ? (
         <GameOverScreen
           crew={crew}
           reason={gameOver}
-          onRestart={() => window.location.reload()}
+          onRestart={restartGame}
         />
       ) : (
         <RaceTrackScene crew={crew} />

--- a/src/components/TrailScene.jsx
+++ b/src/components/TrailScene.jsx
@@ -8,8 +8,11 @@ export default function TrailScene({ crew, day }) {
       {/* Trail line */}
       <div className="absolute top-1/2 left-4 right-4 h-2 bg-gray-600 rounded-full" />
 
-      {/* Milestones */}
-
+        {/* Milestones */}
+        <div className="absolute top-0 left-2 text-sm">🚩</div>
+        <div className="absolute top-0 left-[33%] text-sm animate-pulse">🏕</div>
+        <div className="absolute top-0 left-[66%] text-sm animate-pulse">⛺</div>
+        <div className="absolute top-0 right-2 text-sm animate-bounce">🕹</div>
 
       {/* Avatars based on snack performance */}
       {crew.map((member, idx) => {

--- a/src/components/TrailScenePlus.jsx
+++ b/src/components/TrailScenePlus.jsx
@@ -17,10 +17,14 @@ const animateClass = member.fx || '';
             {/* Track line */}
             <div className="absolute top-1/2 left-4 right-4 h-2 bg-gradient-to-r from-gray-600 to-gray-800 rounded-full" />
 
-            {/* Milestones */}
-            {idx === 0 && <div className="absolute top-0 left-[33%] text-sm animate-pulse">🏕</div>️</div>}
-            {idx === 0 && <div className="absolute top-0 left-[66%] text-sm animate-pulse">⛺</div>}
-            {idx === 0 && <div className="absolute top-0 right-4 text-sm animate-bounce">🕹</div>️</div>}
+          {/* Milestones */}
+          {idx === 0 && (
+            <>
+              <div className="absolute top-0 left-[33%] text-sm animate-pulse">🏕</div>
+              <div className="absolute top-0 left-[66%] text-sm animate-pulse">⛺</div>
+              <div className="absolute top-0 right-4 text-sm animate-bounce">🕹</div>
+            </>
+          )}
 
             {/* Avatar */}
             <div

--- a/src/features/SnackTrail/SnackTrail.jsx
+++ b/src/features/SnackTrail/SnackTrail.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { FaHamburger, FaLaugh } from 'react-icons/fa';
 
+// NOTE: This file represents an early Snack Trail prototype.
+// The main game component now lives in src/components/SnackTrail.jsx
+
 /* tiny event pool – add more lines whenever the kids think of them */
 const events = [
   { msg: "A seagull steals your fries!", snack: -5 },


### PR DESCRIPTION
## Summary
- mark old SnackTrail prototype as legacy
- fix malformed milestone JSX in TrailScenePlus
- add milestone icons to TrailScene
- add stateful restartGame to avoid page reloads

## Testing
- `npm test` *(fails: react-scripts not found)*