### PR TITLE
[brian_m] Add MatrixV1 path continuation pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,8 @@ import Observer from './pages/matrix-v1/Observer';
 import Stage1 from './pages/matrix-v1/Stage1';
 import Stage2 from './pages/matrix-v1/Stage2';
 import Stage3 from './pages/matrix-v1/Stage3';
+import PathA from './pages/matrix-v1/PathA';
+import PathB from './pages/matrix-v1/PathB';
 
 export default function App() {
   return (
@@ -53,6 +55,8 @@ export default function App() {
             <Route path="/matrix-v1/stage-1" element={<Stage1 />} />
             <Route path="/matrix-v1/stage-2" element={<Stage2 />} />
             <Route path="/matrix-v1/stage-3" element={<Stage3 />} />
+            <Route path="/matrix-v1/path-a" element={<PathA />} />
+            <Route path="/matrix-v1/path-b" element={<PathB />} />
             {/* Legacy Matrix Routes - Redirect to V1 */}
             <Route path="/the-matrix/*" element={<Navigate to="/matrix-v1" replace />} />
             <Route path="*" element={<Navigate to="/snack-trail" />} />

--- a/src/__tests__/MatrixV1PathA.test.jsx
+++ b/src/__tests__/MatrixV1PathA.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PathA from '../pages/matrix-v1/PathA';
+
+function setup(hasAccess = true) {
+  if (hasAccess) localStorage.setItem('matrixV1Access', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/path-a']}>
+      <Routes>
+        <Route path="/matrix-v1/path-a" element={<PathA />} />
+        <Route path="/matrix-v1/terminal" element={<div>Terminal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+test('redirects to terminal without access', () => {
+  setup(false);
+  expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+});
+
+test('shows archivist prompt after sequence', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    jest.advanceTimersByTime(10000);
+  });
+  expect(screen.getByText(/continue deeper into the archive/i)).toBeInTheDocument();
+});

--- a/src/__tests__/MatrixV1PathB.test.jsx
+++ b/src/__tests__/MatrixV1PathB.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PathB from '../pages/matrix-v1/PathB';
+
+function setup(hasAccess = true) {
+  if (hasAccess) localStorage.setItem('matrixV1Access', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/path-b']}>
+      <Routes>
+        <Route path="/matrix-v1/path-b" element={<PathB />} />
+        <Route path="/matrix-v1/terminal" element={<div>Terminal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+test('redirects to terminal without access', () => {
+  setup(false);
+  expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+});
+
+test('shows options after messages', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+  expect(screen.getByRole('button', { name: /mask signature/i })).toBeInTheDocument();
+});

--- a/src/pages/matrix-v1/PathA.jsx
+++ b/src/pages/matrix-v1/PathA.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import MatrixRain from '../../components/MatrixRain';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import NPC from './components/NPC';
+
+const MESSAGES = [
+  'You chose transparency. Few do.',
+  "We've compiled your fragments..."
+];
+
+const TRAITS = ['RESISTANT', 'CURIOUS', 'UNSTABLE'];
+
+export default function PathA() {
+  const navigate = useNavigate();
+  const [msgIndex, setMsgIndex] = useState(0);
+  const [typedMsg, doneMsg] = useTypewriterEffect(MESSAGES[msgIndex] || '', 50);
+  const [profiling, setProfiling] = useState(false);
+  const [traitIndex, setTraitIndex] = useState(0);
+  const [typedTrait, doneTrait] = useTypewriterEffect(profiling ? TRAITS[traitIndex] : '', 30);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [glitch, setGlitch] = useState(false);
+
+  useEffect(() => {
+    console.log('[MatrixV1] Path A reached');
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (doneMsg && msgIndex < MESSAGES.length - 1) {
+      const t = setTimeout(() => setMsgIndex(i => i + 1), 1000);
+      return () => clearTimeout(t);
+    }
+    if (doneMsg && msgIndex === MESSAGES.length - 1) {
+      setProfiling(true);
+    }
+  }, [doneMsg, msgIndex]);
+
+  useEffect(() => {
+    if (profiling && doneTrait && traitIndex < TRAITS.length - 1) {
+      const t = setTimeout(() => setTraitIndex(i => i + 1), 1000);
+      return () => clearTimeout(t);
+    }
+    if (profiling && doneTrait && traitIndex === TRAITS.length - 1) {
+      setShowPrompt(true);
+    }
+  }, [profiling, doneTrait, traitIndex]);
+
+  const deeper = () => navigate('/matrix-v1/deeper-profile');
+  const eject = () => {
+    setGlitch(true);
+    setTimeout(() => navigate('/matrix-v1/trace'), 800);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className={`relative z-10 flex flex-col items-center space-y-6 ${glitch ? 'animate-glitch' : ''}`}>
+        {!profiling && <p className="text-xl text-center max-w-md">{typedMsg}</p>}
+        {profiling && (
+          <p className="text-2xl font-bold animate-pulse">{typedTrait}</p>
+        )}
+        {showPrompt && (
+          <>
+            <NPC name="Archivist AI" quote="You may not like what you see. But you must own it." style="oracle" />
+            <p className="text-lg text-center">Continue deeper into the archive?</p>
+            <div className="flex space-x-4">
+              <button onClick={deeper} className="px-6 py-2 rounded bg-green-900 text-green-400 hover:bg-green-800">Yes</button>
+              <button onClick={eject} className="px-6 py-2 rounded bg-red-900 text-red-400 hover:bg-red-800">No</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/PathB.jsx
+++ b/src/pages/matrix-v1/PathB.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import MatrixRain from '../../components/MatrixRain';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import NPC from './components/NPC';
+
+const MESSAGES = [
+  'Resistance registered.',
+  'System instability rising.'
+];
+
+export default function PathB() {
+  const navigate = useNavigate();
+  const [msgIndex, setMsgIndex] = useState(0);
+  const [typedMsg, doneMsg] = useTypewriterEffect(MESSAGES[msgIndex] || '', 50);
+  const [showOptions, setShowOptions] = useState(false);
+  const [glitch, setGlitch] = useState(false);
+  const [count, setCount] = useState(3);
+  const [injecting, setInjecting] = useState(false);
+
+  useEffect(() => {
+    console.log('[MatrixV1] Path B reached');
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (doneMsg && msgIndex < MESSAGES.length - 1) {
+      const t = setTimeout(() => setMsgIndex(i => i + 1), 1000);
+      return () => clearTimeout(t);
+    }
+    if (doneMsg && msgIndex === MESSAGES.length - 1) {
+      setShowOptions(true);
+    }
+  }, [doneMsg, msgIndex]);
+
+  const mask = () => {
+    setGlitch(true);
+    setTimeout(() => navigate('/matrix-v1/path-b-glitch'), 800);
+  };
+
+  const inject = () => {
+    setShowOptions(false);
+    setInjecting(true);
+    let c = 3;
+    setCount(c);
+    const interval = setInterval(() => {
+      c -= 1;
+      setCount(c);
+      if (c <= 0) {
+        clearInterval(interval);
+        navigate('/matrix-v1/interference');
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      {/* distortion overlay */}
+      <div className="absolute inset-0 pointer-events-none z-20 animate-pulse" style={{ mixBlendMode: 'screen', opacity: 0.2 }} />
+      <div className={`relative z-10 flex flex-col items-center space-y-6 ${glitch ? 'animate-glitch' : ''}`}>
+        {!showOptions && <p className="text-xl text-center max-w-md">{typedMsg}</p>}
+        {showOptions ? (
+          <>
+            <NPC name="Agent Echo" quote="You thought you could hide. But you've been tagged." style="agent" />
+            <div className="flex flex-col items-center space-y-4">
+              <button onClick={mask} className="px-6 py-2 rounded bg-purple-900 text-purple-400 hover:bg-purple-800">Mask signature</button>
+              <button onClick={inject} className="px-6 py-2 rounded bg-red-900 text-red-400 hover:bg-red-800">Inject static</button>
+            </div>
+          </>
+        ) : null}
+        {injecting && (
+          <p className="text-2xl font-bold animate-pulse">{count}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/Stage3.jsx
+++ b/src/pages/matrix-v1/Stage3.jsx
@@ -42,9 +42,9 @@ export default function Stage3() {
   const handlePath = (path) => {
     localStorage.setItem('matrixV1Fork', path);
     if (path === 'A') {
-      navigate('/profile-report');
+      navigate('/matrix-v1/path-a');
     } else {
-      navigate('/hidden-path');
+      navigate('/matrix-v1/path-b');
     }
   };
 


### PR DESCRIPTION
## Summary
- add continuation pages `PathA` and `PathB`
- route Stage3 choices to these new pages
- register new routes in `App.js`
- test that the new pages render when Matrix access is granted

## Testing
- `npm test --silent` *(fails: react-scripts not found)*