### PR TITLE
[brian_m] allow skipping matrix intro messages

### DIFF
--- a/src/__tests__/MatrixV1Message.test.jsx
+++ b/src/__tests__/MatrixV1Message.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Message from '../pages/matrix-v1/Message';
@@ -32,31 +32,19 @@ test('shows first message and progress indicator', () => {
   expect(screen.getByText(/message 1 of 6/i)).toBeInTheDocument();
 });
 
-test('shows next button after message is done', async () => {
+test('shows next button immediately', () => {
   localStorage.setItem('matrixV1Access', 'true');
   setup();
-  // Wait for typewriter effect to complete
-  await act(async () => {
-    jest.advanceTimersByTime(2000);
-  });
   expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
 });
 
 test('navigates through all messages and to stage1', async () => {
   localStorage.setItem('matrixV1Access', 'true');
   setup();
-  
-  // Wait for first message to complete
-  await act(async () => {
-    jest.advanceTimersByTime(2000);
-  });
 
-  // Click through all messages
+  // Click through all messages without waiting
   for (let i = 0; i < 5; i++) {
     await userEvent.click(screen.getByRole('button', { name: /next/i }));
-    await act(async () => {
-      jest.advanceTimersByTime(2000);
-    });
   }
 
   // Click final continue button

--- a/src/components/useTypewriterEffect.js
+++ b/src/components/useTypewriterEffect.js
@@ -7,6 +7,13 @@ export default function useTypewriterEffect(fullText = '', speed = 50) {
   const prevTextRef = useRef(null);
   const timeoutRef = useRef();
 
+  const skip = () => {
+    clearInterval(timeoutRef.current);
+    prevTextRef.current = fullText;
+    setText(fullText);
+    setDone(true);
+  };
+
   useEffect(() => {
     if (prevTextRef.current === fullText) return;
     prevTextRef.current = fullText;
@@ -28,5 +35,5 @@ export default function useTypewriterEffect(fullText = '', speed = 50) {
     return () => clearInterval(timeoutRef.current);
   }, [fullText, speed]);
 
-  return [text, done];
+  return [text, done, skip];
 }

--- a/src/pages/matrix-v1/Message.jsx
+++ b/src/pages/matrix-v1/Message.jsx
@@ -64,18 +64,15 @@ export default function Message() {
           Message {currentIndex + 1} of {MESSAGES.length}
         </div>
 
-        {/* Show button and attribution only when current message is done */}
-        {done && (
-          <div className="flex flex-col items-center space-y-4">
-            <p className="text-sm text-green-700">— Morpheus</p>
-            <button
-              onClick={handleNext}
-              className="px-6 py-3 rounded bg-green-700 text-black hover:bg-green-600 transition-colors"
-            >
-              {currentIndex < MESSAGES.length - 1 ? 'Next' : 'Continue'}
-            </button>
-          </div>
-        )}
+        <div className="flex flex-col items-center space-y-4">
+          {done && <p className="text-sm text-green-700">— Morpheus</p>}
+          <button
+            onClick={handleNext}
+            className="px-6 py-3 rounded bg-green-700 text-black hover:bg-green-600 transition-colors"
+          >
+            {currentIndex < MESSAGES.length - 1 ? 'Next' : 'Continue'}
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep `Next` button available during Matrix intro messages so testers don't have to wait
- expose a `skip` helper in `useTypewriterEffect`
- update unit tests for new behaviour

## Testing
- `npm test` *(fails: react-scripts not found)*