### PR TITLE
[brian_m] Add glitch continuation screens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,8 @@ import Stage3 from './pages/matrix-v1/Stage3';
 import PathA from './pages/matrix-v1/PathA';
 import PathB from './pages/matrix-v1/PathB';
 import DeeperProfile from './pages/matrix-v1/DeeperProfile';
+import Interference from './pages/matrix-v1/Interference';
+import PathBGlitch from './pages/matrix-v1/PathBGlitch';
 
 export default function App() {
   return (
@@ -59,6 +61,8 @@ export default function App() {
             <Route path="/matrix-v1/path-a" element={<PathA />} />
             <Route path="/matrix-v1/path-b" element={<PathB />} />
             <Route path="/matrix-v1/deeper-profile" element={<DeeperProfile />} />
+            <Route path="/matrix-v1/interference" element={<Interference />} />
+            <Route path="/matrix-v1/path-b-glitch" element={<PathBGlitch />} />
             {/* Legacy Matrix Routes - Redirect to V1 */}
             <Route path="/the-matrix/*" element={<Navigate to="/matrix-v1" replace />} />
             <Route path="*" element={<Navigate to="/snack-trail" />} />

--- a/src/__tests__/MatrixV1Interference.test.jsx
+++ b/src/__tests__/MatrixV1Interference.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Interference from '../pages/matrix-v1/Interference';
+
+function setup(hasAccess = true) {
+  if (hasAccess) localStorage.setItem('matrixV1Access', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/interference']}>
+      <Routes>
+        <Route path="/matrix-v1/interference" element={<Interference />} />
+        <Route path="/matrix-v1/terminal" element={<div>Terminal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+test('redirects to terminal without access', () => {
+  setup(false);
+  expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+});
+
+test('shows options after messages', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+  expect(screen.getByRole('button', { name: /try to stabilize/i })).toBeInTheDocument();
+});

--- a/src/__tests__/MatrixV1PathBGlitch.test.jsx
+++ b/src/__tests__/MatrixV1PathBGlitch.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PathBGlitch from '../pages/matrix-v1/PathBGlitch';
+
+function setup(hasAccess = true) {
+  if (hasAccess) localStorage.setItem('matrixV1Access', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/path-b-glitch']}>
+      <Routes>
+        <Route path="/matrix-v1/path-b-glitch" element={<PathBGlitch />} />
+        <Route path="/matrix-v1/terminal" element={<div>Terminal</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+test('redirects to terminal without access', () => {
+  setup(false);
+  expect(screen.getByText(/terminal/i)).toBeInTheDocument();
+});
+
+test('shows options after messages', () => {
+  jest.useFakeTimers();
+  setup();
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+  expect(screen.getByRole('button', { name: /play along/i })).toBeInTheDocument();
+});

--- a/src/pages/matrix-v1/Interference.jsx
+++ b/src/pages/matrix-v1/Interference.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import MatrixRain from '../../components/MatrixRain';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import NPC from './components/NPC';
+
+function reverse(str) {
+  return str.split('').reverse().join('');
+}
+
+const MESSAGES = [
+  '...sign4l br3ach...',
+  'Misfire: ::NPC:: //??',
+  'You are no longer being tracked.'
+];
+
+export default function Interference() {
+  const navigate = useNavigate();
+  const [index, setIndex] = useState(0);
+  const [typed, done] = useTypewriterEffect(reverse(MESSAGES[index] || ''), 50);
+  const [showOptions, setShowOptions] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (done && index < MESSAGES.length - 1) {
+      const t = setTimeout(() => setIndex(i => i + 1), 800);
+      return () => clearTimeout(t);
+    }
+    if (done && index === MESSAGES.length - 1) {
+      setShowOptions(true);
+    }
+  }, [done, index]);
+
+  const stabilize = () => navigate('/matrix-v1/stabilize');
+  const descend = () => navigate('/matrix-v1/error-loop');
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6">
+        <p className="text-xl text-center whitespace-pre">{typed}</p>
+        {showOptions && (
+          <>
+            <NPC name="Archivist?" quote="Sy$t3m err..." style="oracle" />
+            <NPC name="Agent Shadow" quote="T-r-a-c-k-l-o-s-t" style="agent" />
+            <div className="flex space-x-4 mt-4">
+              <button onClick={stabilize} className="px-6 py-2 rounded bg-purple-900 text-purple-400 hover:bg-purple-800">
+                Try to stabilize
+              </button>
+              <button onClick={descend} className="px-6 py-2 rounded bg-red-900 text-red-400 hover:bg-red-800">
+                Descend further
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/PathBGlitch.jsx
+++ b/src/pages/matrix-v1/PathBGlitch.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import MatrixRain from '../../components/MatrixRain';
+import useTypewriterEffect from '../../components/useTypewriterEffect';
+import NPC from './components/NPC';
+
+const LINES = [
+  'System nominal... Welcome back.',
+  'Archivist: "All is well, proceed as usual."'
+];
+
+export default function PathBGlitch() {
+  const navigate = useNavigate();
+  const [index, setIndex] = useState(0);
+  const [typed, done] = useTypewriterEffect(LINES[index] || '', 50);
+  const [showOptions, setShowOptions] = useState(false);
+  const [glitch, setGlitch] = useState(true);
+
+  useEffect(() => {
+    if (localStorage.getItem('matrixV1Access') !== 'true') {
+      navigate('/matrix-v1/terminal');
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (done && index < LINES.length - 1) {
+      const t = setTimeout(() => setIndex(i => i + 1), 800);
+      return () => clearTimeout(t);
+    }
+    if (done && index === LINES.length - 1) {
+      setShowOptions(true);
+    }
+  }, [done, index]);
+
+  const playAlong = () => navigate('/matrix-v1/deeper-profile');
+  const reset = () => navigate('/matrix-v1', { state: { glitch: true } });
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className={`relative z-10 flex flex-col items-center space-y-6 ${glitch ? 'animate-glitch' : ''}`}>
+        <p className="text-xl text-center whitespace-pre-line">{typed}</p>
+        {showOptions && (
+          <>
+            <NPC name="Archivist" quote="Everything is fine." style="oracle" />
+            <div className="flex space-x-4 mt-4">
+              <button onClick={playAlong} className="px-6 py-2 rounded bg-green-900 text-green-400 hover:bg-green-800">
+                Play along
+              </button>
+              <button onClick={reset} className="px-6 py-2 rounded bg-yellow-900 text-yellow-400 hover:bg-yellow-800">
+                Attempt reset
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce **Interference** screen with reversed text and corrupted NPC prompts
- introduce **PathBGlitch** screen where Archivist pretends system is normal
- wire new screens into app routing
- add tests for new screens

## Testing
- `npm test` *(fails: react-scripts not found)*