### PR TITLE
[brian_m] Add interactive progress to matrix map

### DIFF
--- a/src/__tests__/MatrixV1Map.test.jsx
+++ b/src/__tests__/MatrixV1Map.test.jsx
@@ -1,17 +1,10 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Map from '../pages/matrix-v1/Map';
 
-const originalFetch = global.fetch;
-
-beforeEach(() => {
-  global.fetch = jest.fn(() =>
-    Promise.resolve({ text: () => Promise.resolve('graph TD;') })
-  );
-});
-
 afterEach(() => {
-  global.fetch = originalFetch;
+  localStorage.clear();
 });
 
 function setup(initialEntries = ['/matrix-v1/map']) {
@@ -24,8 +17,16 @@ function setup(initialEntries = ['/matrix-v1/map']) {
   );
 }
 
-test('renders matrix story map heading', () => {
+test('highlights current node from localStorage', () => {
+  localStorage.setItem('currentNodeId', 'start');
   setup();
-  expect(screen.getByRole('heading', { name: /matrix story map/i })).toBeInTheDocument();
-  expect(global.fetch).toHaveBeenCalled();
+  expect(document.querySelector('.matrix-glow-green')).toBeInTheDocument();
+});
+
+test('toggles dev view legend', async () => {
+  setup();
+  const button = screen.getByRole('button', { name: /dev view/i });
+  expect(screen.queryByText(/legend/i)).not.toBeInTheDocument();
+  await userEvent.click(button);
+  expect(screen.getByText(/legend/i)).toBeInTheDocument();
 });

--- a/src/components/MatrixV1Terminal.jsx
+++ b/src/components/MatrixV1Terminal.jsx
@@ -4,6 +4,7 @@ import { UserContext } from './UserContext';
 import { NAOE_QUOTES } from '../data/naoeQuotes';
 import useTypewriterEffect from './useTypewriterEffect';
 import MatrixRain from './MatrixRain';
+import useMatrixProgress from './useMatrixProgress';
 
 const QUOTE_OPTIONS = [
   { text: 'There is no...', options: ['Door', 'Spoon', 'Exit', 'Escape'], correct: 'Spoon' },
@@ -13,6 +14,7 @@ const QUOTE_OPTIONS = [
 
 export default function MatrixV1Terminal() {
   const { userName } = useContext(UserContext);
+  useMatrixProgress('start');
   const [selectedQuote, setSelectedQuote] = useState(null);
   const [msg, setMsg] = useState('');
   const [ok, setOk] = useState(false);

--- a/src/components/useMatrixProgress.js
+++ b/src/components/useMatrixProgress.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+
+export default function useMatrixProgress(nodeId) {
+  useEffect(() => {
+    if (!nodeId) return;
+    try {
+      localStorage.setItem('currentNodeId', nodeId);
+      const visited = JSON.parse(localStorage.getItem('visitedNodes') || '[]');
+      if (!visited.includes(nodeId)) {
+        visited.push(nodeId);
+        localStorage.setItem('visitedNodes', JSON.stringify(visited));
+      }
+    } catch (err) {
+      // ignore write errors (e.g. SSR)
+    }
+  }, [nodeId]);
+}

--- a/src/pages/matrix-v1/CustomNode.jsx
+++ b/src/pages/matrix-v1/CustomNode.jsx
@@ -98,12 +98,14 @@ const factionColors = {
   },
 };
 
-export default function CustomNode({ data, type, selected }) {
+export default function CustomNode({ data, type, selected, visited }) {
   let className = '';
   if (selected) {
     className += ' matrix-glow-green';
   } else if (data.recommended) {
     className += ' matrix-glow-purple';
+  } else if (visited) {
+    className += ' matrix-glow-green';
   } else if (data.type === 'trap') {
     className += ' matrix-trap-red';
   } else if (data.type === 'choice') {
@@ -128,6 +130,10 @@ export default function CustomNode({ data, type, selected }) {
   }
   if (data.type === 'training') {
     style = nodeStyles.training;
+  }
+
+  if (selected) {
+    style = { ...style, border: '4px solid #00ff00' };
   }
 
   const badge = statusBadge[data.status] || '';

--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -1,19 +1,74 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactFlow from 'reactflow';
 import 'reactflow/dist/base.css';
 import { nodes } from './nodes';
 import { edges } from './edges';
 import CustomNode from './CustomNode';
 
-const nodeTypes = {
-  npc: (props) => <CustomNode {...props} type="npc" selected={props.id === 'start'} />,
-  choice: (props) => <CustomNode {...props} type="choice" selected={false} />,
-  end: (props) => <CustomNode {...props} type="end" selected={false} />,
-};
+function createNodeTypes(currentId, visited) {
+  return {
+    npc: (props) => (
+      <CustomNode
+        {...props}
+        type="npc"
+        selected={props.id === currentId}
+        visited={visited.includes(props.id)}
+      />
+    ),
+    choice: (props) => (
+      <CustomNode
+        {...props}
+        type="choice"
+        selected={props.id === currentId}
+        visited={visited.includes(props.id)}
+      />
+    ),
+    end: (props) => (
+      <CustomNode
+        {...props}
+        type="end"
+        selected={props.id === currentId}
+        visited={visited.includes(props.id)}
+      />
+    ),
+    faction: (props) => (
+      <CustomNode
+        {...props}
+        type="faction"
+        selected={props.id === currentId}
+        visited={visited.includes(props.id)}
+      />
+    ),
+    training: (props) => (
+      <CustomNode
+        {...props}
+        type="training"
+        selected={props.id === currentId}
+        visited={visited.includes(props.id)}
+      />
+    ),
+  };
+}
 
 export default function MapPage() {
   const [devView, setDevView] = useState(false);
-  // For now, only highlight the start node as current
+  const [currentId, setCurrentId] = useState('start');
+  const [visited, setVisited] = useState([]);
+
+  useEffect(() => {
+    const id = localStorage.getItem('currentNodeId') || 'start';
+    let visitedList = [];
+    try {
+      visitedList = JSON.parse(localStorage.getItem('visitedNodes') || '[]');
+    } catch {
+      visitedList = [];
+    }
+    setCurrentId(id);
+    setVisited(visitedList);
+  }, []);
+
+  const nodeTypes = createNodeTypes(currentId, visited);
+
   return (
     <div style={{ height: '90vh', background: '#0f0f0f', position: 'relative' }}>
       <div style={{ position: 'absolute', top: 10, right: 20, zIndex: 10 }}>
@@ -34,6 +89,24 @@ export default function MapPage() {
           🧪 Dev View
         </button>
       </div>
+      {devView && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 60,
+            right: 20,
+            background: '#111',
+            color: '#fff',
+            padding: '8px 12px',
+            borderRadius: 8,
+            fontSize: 14,
+            zIndex: 10,
+          }}
+        >
+          <div className="font-bold mb-1">Legend</div>
+          <div>✅ built, 🛠 in progress, ❌ planned</div>
+        </div>
+      )}
       <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} fitView />
     </div>
   );


### PR DESCRIPTION
## Summary
- track current matrix node with `useMatrixProgress`
- highlight visited/current nodes in `Map` and `CustomNode`
- show legend when Dev View enabled
- update tests for new behavior

## Testing
- `npm test` *(fails: react-scripts not found)*