### PR TITLE
[brian_m] Add landing page with icon grid

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import LegoInventory from './components/LegoInventory';
 import LittleAlchemy from './components/LittleAlchemy';
 import RCPlaneDesigner from './components/RCPlaneDesigner';
 import Updates from './components/Updates';
+import Home from './components/Home';
 // Matrix V1 Pages
 import Entry from './pages/matrix-v1/Entry';
 import Terminal from './pages/matrix-v1/Terminal';
@@ -42,6 +43,7 @@ export default function App() {
           <Navigation />
           <Breadcrumbs />
           <Routes>
+            <Route path="/" element={<Home />} />
             <Route path="/snack-trail" element={<SnackTrailPage />} />
             <Route path="/pixel-art" element={<PixelArtMaker />} />
             <Route path="/robot-lab" element={<RobotLab />} />
@@ -71,7 +73,7 @@ export default function App() {
             <Route path="/matrix-v1/align-:slug" element={<Align />} />
             {/* Legacy Matrix Routes - Redirect to V1 */}
             <Route path="/the-matrix/*" element={<Navigate to="/matrix-v1" replace />} />
-            <Route path="*" element={<Navigate to="/snack-trail" />} />
+            <Route path="*" element={<Navigate to="/" />} />
           </Routes>
         </div>
       </Router>

--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../components/Home';
+import { UserProvider } from '../components/UserContext';
+
+test('displays links to main features', () => {
+  render(
+    <UserProvider>
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    </UserProvider>
+  );
+
+  expect(screen.getByRole('link', { name: /trail/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /pixel lab/i })).toBeInTheDocument();
+});

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { navItems } from './Navigation';
+import useTypewriterEffect from './useTypewriterEffect';
+import MatrixRain from './MatrixRain';
+
+export default function Home() {
+  const [welcomeText] = useTypewriterEffect('Welcome to Brian\'s Playground', 50);
+  const [promptText] = useTypewriterEffect('Choose your destination', 50);
+
+  return (
+    <div className="p-8 text-center space-y-6 min-h-screen relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-6">
+        <h1 className="text-4xl font-bold text-green-400 font-mono">{welcomeText}</h1>
+        <p className="text-lg text-green-200 font-mono">{promptText}</p>
+        <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+          {navItems.map(({ name, path, color, icon: Icon }) => (
+            <Link
+              key={path}
+              to={path}
+              className={`flex flex-col items-center py-6 rounded-lg font-semibold shadow-md hover:scale-105 transition-transform ${color}`}
+            >
+              {Icon && <Icon className="mb-2 text-2xl" />}
+              {name}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -15,13 +15,13 @@ import {
 } from 'react-icons/fa';
 
 export const navItems = [
-  { name: 'The Trail',      path: '/snack-trail',      color: 'bg-yellow-400 text-black' },
-  { name: 'Pixel Lab',      path: '/pixel-art',        color: 'bg-blue-500' },
-  { name: 'Robot Room',     path: '/robot-lab',        color: 'bg-green-500' },
-  { name: 'Build Mode',     path: '/lego-build',       color: 'bg-red-500' },
-  { name: 'Inventory',      path: '/lego-inventory',   color: 'bg-yellow-600' },
-  { name: 'Alchemy',        path: '/little-alchemy',   color: 'bg-cyan-500' },
-  { name: 'The Matrix',     path: '/matrix-v1',        color: 'bg-green-700 text-black' },
+  { name: 'The Trail',      path: '/snack-trail',      color: 'bg-yellow-400 text-black', icon: FaRoad },
+  { name: 'Pixel Lab',      path: '/pixel-art',        color: 'bg-blue-500', icon: FaPaintBrush },
+  { name: 'Robot Room',     path: '/robot-lab',        color: 'bg-green-500', icon: FaRobot },
+  { name: 'Build Mode',     path: '/lego-build',       color: 'bg-red-500', icon: FaCube },
+  { name: 'Inventory',      path: '/lego-inventory',   color: 'bg-yellow-600', icon: FaBox },
+  { name: 'Alchemy',        path: '/little-alchemy',   color: 'bg-cyan-500', icon: FaFlask },
+  { name: 'The Matrix',     path: '/matrix-v1',        color: 'bg-green-700 text-black', icon: FaCodeBranch },
   { name: 'Story Map',      path: '/matrix-v1/map',    color: 'bg-purple-500', icon: FaCompass }
 ];
 


### PR DESCRIPTION
## Summary
- create a `Home` component that shows a Matrix‑style welcome and grid of nav items
- add icons to all navigation items
- route `/` to the new home page instead of redirecting to `/snack-trail`
- test new home page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*