### PR TITLE
[brian_m] Improve matrix map usability

### DIFF
--- a/src/pages/matrix-v1/CustomNode.jsx
+++ b/src/pages/matrix-v1/CustomNode.jsx
@@ -113,6 +113,9 @@ export default function CustomNode({ data, type, selected }) {
   } else if (data.type === 'training') {
     className += ' matrix-gradient-purple';
   }
+  if (data.status === 'live') {
+    className += ' shadow-[0_0_8px_rgba(0,255,0,0.3)]';
+  }
 
   let style = nodeStyles[data.type] || nodeStyles.unknown;
   if (data.type === 'faction') {
@@ -134,11 +137,16 @@ export default function CustomNode({ data, type, selected }) {
 
   return (
     <div
-      className={className + ' relative cursor-pointer font-semibold rounded-lg px-4 py-3 min-w-[110px] text-center'}
+      className={
+        className +
+        ' relative font-semibold rounded-lg px-4 py-3 min-w-[110px] text-center transition-transform hover:scale-105 hover:ring-2 hover:ring-lime-400 cursor-pointer'
+      }
       title={data.tooltip || data.label}
       style={{ position: 'relative', ...style }}
     >
-      <span className="block text-lg font-bold">{data.label}</span>
+      <span className="block text-base px-2 py-1 rounded-md bg-white/80 text-black drop-shadow">
+        {data.label}
+      </span>
       {data.guardian && (
         <span className="block text-xs mt-1 opacity-80">{data.guardian}</span>
       )}

--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import ReactFlow from 'reactflow';
+import React, { useState, useCallback } from 'react';
+import ReactFlow, { Background, Controls, MiniMap, ReactFlowProvider, useReactFlow } from 'reactflow';
 import 'reactflow/dist/base.css';
 import { nodes } from './nodes';
 import { edges } from './edges';
@@ -13,28 +13,51 @@ const nodeTypes = {
 
 export default function MapPage() {
   const [devView, setDevView] = useState(false);
+
+  const ResetControl = () => {
+    const { fitView } = useReactFlow();
+    const handleReset = useCallback(() => fitView(), [fitView]);
+    return (
+      <button
+        onClick={handleReset}
+        className="bg-black/50 text-white px-3 py-1 rounded hover:bg-black/70"
+        aria-label="Reset view"
+      >
+        Reset
+      </button>
+    );
+  };
+
   // For now, only highlight the start node as current
   return (
-    <div style={{ height: '90vh', background: '#0f0f0f', position: 'relative' }}>
-      <div style={{ position: 'absolute', top: 10, right: 20, zIndex: 10 }}>
-        <button
-          onClick={() => setDevView((v) => !v)}
-          style={{
-            background: devView ? '#222' : '#111',
-            color: devView ? '#00ff00' : '#fff',
-            border: '1px solid #00ff00',
-            borderRadius: 8,
-            padding: '6px 16px',
-            fontWeight: 600,
-            fontSize: 16,
-            cursor: 'pointer',
-            boxShadow: devView ? '0 0 8px #00ff00' : 'none',
-          }}
-        >
-          🧪 Dev View
-        </button>
+    <ReactFlowProvider>
+      <div className="relative h-[90vh] bg-gradient-to-b from-black via-neutral-900 to-black">
+        <h1 className="absolute top-2 left-4 text-xl font-bold">Matrix Story Map</h1>
+        <div className="absolute top-2 right-4 z-10 flex items-center gap-2">
+          <button
+            onClick={() => setDevView((v) => !v)}
+            style={{
+              background: devView ? '#222' : '#111',
+              color: devView ? '#00ff00' : '#fff',
+              border: '1px solid #00ff00',
+              borderRadius: 8,
+              padding: '6px 16px',
+              fontWeight: 600,
+              fontSize: 16,
+              cursor: 'pointer',
+              boxShadow: devView ? '0 0 8px #00ff00' : 'none',
+            }}
+          >
+            🧪 Dev View
+          </button>
+          <ResetControl />
+        </div>
+        <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} fitView className="w-full h-full">
+          <Background color="#222" />
+          <MiniMap className="bg-black/60" />
+          <Controls />
+        </ReactFlow>
       </div>
-      <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} fitView />
-    </div>
+    </ReactFlowProvider>
   );
 }


### PR DESCRIPTION
## Summary
- refine CustomNode labels with contrasting styles and hover effects
- add zoom, minimap, and reset controls to Matrix Map view
- style map background and expose "Matrix Story Map" heading

## Testing
- `npm test --silent` *(fails: react-scripts not found)*