### PR TITLE
[brian_m] style map nodes

### DIFF
--- a/src/pages/matrix-v1/CustomNode.jsx
+++ b/src/pages/matrix-v1/CustomNode.jsx
@@ -140,11 +140,13 @@ export default function CustomNode({ data, type, selected, visited }) {
 
   return (
     <div
-      className={className + ' relative cursor-pointer font-extrabold rounded-lg px-4 py-3 min-w-[110px] text-center'}
+      className={className + ' relative cursor-pointer font-extrabold rounded-lg px-4 py-3 min-w-[110px] text-center m-2'}
       title={data.tooltip || data.label}
       style={{ position: 'relative', ...style }}
     >
-      <span className="block text-xl font-extrabold">{data.label}</span>
+      <span className="text-sm md:text-base px-2 py-1 rounded-md bg-white bg-opacity-80 text-black shadow-md hover:scale-105 transition-transform cursor-pointer">
+        {data.label}
+      </span>
       {data.guardian && (
         <span className="block text-sm mt-1 opacity-80">{data.guardian}</span>
       )}

--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -70,7 +70,7 @@ export default function MapPage() {
   const nodeTypes = createNodeTypes(currentId, visited);
 
   return (
-    <div style={{ height: '90vh', background: '#0f0f0f', position: 'relative' }}>
+    <div className="relative bg-black bg-gradient-to-br from-gray-900 to-black min-h-screen p-8 overflow-hidden">
       <div style={{ position: 'absolute', top: 10, right: 20, zIndex: 10 }}>
         <button
           onClick={() => setDevView((v) => !v)}


### PR DESCRIPTION
## Summary
- tweak map container for better contrast
- wrap map node labels in styled span for readability

## Testing
- `npm test` *(fails: react-scripts not found)*