### PR TITLE
[brian_m] isolate ReactFlow to map canvas

### DIFF
--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import ReactFlow, { Background, Controls, MiniMap, ReactFlowProvider, useReactFlow, useStore } from 'reactflow';
+import React, { useState, useEffect } from 'react';
 import 'reactflow/dist/base.css';
 import { nodes } from './nodes';
 import { edges } from './edges';
 import CustomNode from './CustomNode';
-import ZoomHUD from './ZoomHUD';
+import MapCanvas from './MapCanvas';
+import Navigation from '../../components/Navigation';
+import Breadcrumbs from '../../components/Breadcrumbs';
 
 function createNodeTypes(currentId, visited) {
   return {
@@ -70,74 +71,49 @@ export default function MapPage() {
 
   const nodeTypes = createNodeTypes(currentId, visited);
 
-  // Phase 1B: Zoom Utility Overlay
-  const zoom = useStore((s) => s.transform[2]);
-  const { setViewport } = useReactFlow();
-  const handleReset = useCallback(() => {
-    setViewport({ x: 0, y: 0, zoom: 1, duration: 400 });
-  }, [setViewport]);
 
   return (
-    <ReactFlowProvider>
-      <div className="relative bg-black bg-gradient-to-br from-gray-900 to-black min-h-screen p-8 overflow-hidden">
-        <div style={{ position: 'absolute', top: 10, right: 20, zIndex: 10 }}>
-          <button
-            onClick={() => setDevView((v) => !v)}
-            style={{
-              background: devView ? '#222' : '#111',
-              color: devView ? '#00ff00' : '#fff',
-              border: '1px solid #00ff00',
-              borderRadius: 8,
-              padding: '6px 16px',
-              fontWeight: 600,
-              fontSize: 16,
-              cursor: 'pointer',
-              boxShadow: devView ? '0 0 8px #00ff00' : 'none',
-            }}
-          >
-            🧪 Dev View
-          </button>
-          {/* Phase 1B: Zoom Utility Overlay */}
-          <div className="text-sm text-white bg-black/50 px-2 py-1 rounded shadow mt-2" title="Zoom level">
-            Zoom: {(zoom * 100).toFixed(0)}%
-            <button
-              onClick={handleReset}
-              className="ml-2 px-2 py-1 rounded bg-gray-800 text-gray-200 border border-gray-600 hover:bg-gray-700 text-xs"
-              style={{ fontSize: 12 }}
-              title="Reset zoom"
-            >
-              Reset
-            </button>
-          </div>
-        </div>
-        {/* Render ZoomHUD overlay */}
-        <ZoomHUD />
-        {devView && (
-          <div
-            style={{
-              position: 'absolute',
-              top: 60,
-              right: 20,
-              background: '#111',
-              color: '#fff',
-              padding: '8px 12px',
-              borderRadius: 8,
-              fontSize: 14,
-              zIndex: 10,
-            }}
-          >
-            <div className="font-bold mb-1">Legend</div>
-            <div>✅ built, 🛠 in progress, ❌ planned</div>
-          </div>
-        )}
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          nodeTypes={nodeTypes}
-          fitView
-          style={{ height: '80vh', backgroundColor: '#111' }}
-        />
+    <div className="relative bg-black bg-gradient-to-br from-gray-900 to-black min-h-screen p-8 overflow-hidden">
+      <Navigation />
+      <Breadcrumbs />
+      <h1 className="sr-only">Matrix Story Map</h1>
+      <div style={{ position: 'absolute', top: 10, right: 20, zIndex: 10 }}>
+        <button
+          onClick={() => setDevView((v) => !v)}
+          style={{
+            background: devView ? '#222' : '#111',
+            color: devView ? '#00ff00' : '#fff',
+            border: '1px solid #00ff00',
+            borderRadius: 8,
+            padding: '6px 16px',
+            fontWeight: 600,
+            fontSize: 16,
+            cursor: 'pointer',
+            boxShadow: devView ? '0 0 8px #00ff00' : 'none',
+          }}
+        >
+          🧪 Dev View
+        </button>
       </div>
-    </ReactFlowProvider>
+      {devView && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 60,
+            right: 20,
+            background: '#111',
+            color: '#fff',
+            padding: '8px 12px',
+            borderRadius: 8,
+            fontSize: 14,
+            zIndex: 10,
+          }}
+        >
+          <div className="font-bold mb-1">Legend</div>
+          <div>✅ built, 🛠 in progress, ❌ planned</div>
+        </div>
+      )}
+      <MapCanvas nodes={nodes} edges={edges} nodeTypes={nodeTypes} />
+    </div>
   );
 }

--- a/src/pages/matrix-v1/MapCanvas.jsx
+++ b/src/pages/matrix-v1/MapCanvas.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactFlow, { ReactFlowProvider } from 'reactflow';
+import 'reactflow/dist/base.css';
+import ZoomHUD from './ZoomHUD';
+
+export default function MapCanvas({ nodes, edges, nodeTypes }) {
+  return (
+    <ReactFlowProvider>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        style={{ height: '80vh', backgroundColor: '#111' }}
+      />
+      <ZoomHUD />
+    </ReactFlowProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- create `MapCanvas` to contain the ReactFlow provider
- update `MapPage` to use the canvas and keep navigation outside the provider

## Testing
- `npm test` *(fails: react-scripts not found)*