### PR TITLE
[brian_m] Add GuardianCall memory puzzle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import Observer from './pages/matrix-v1/Observer';
 import Stage1 from './pages/matrix-v1/Stage1';
 import Stage2 from './pages/matrix-v1/Stage2';
 import Stage3 from './pages/matrix-v1/Stage3';
+import GuardianCall from './pages/matrix-v1/GuardianCall';
 import PathA from './pages/matrix-v1/PathA';
 import PathB from './pages/matrix-v1/PathB';
 import DeeperProfile from './pages/matrix-v1/DeeperProfile';
@@ -63,6 +64,7 @@ export default function App() {
             <Route path="/matrix-v1/stage-1" element={<Stage1 />} />
             <Route path="/matrix-v1/stage-2" element={<Stage2 />} />
             <Route path="/matrix-v1/stage-3" element={<Stage3 />} />
+            <Route path="/matrix-v1/guardian-call" element={<GuardianCall />} />
             <Route path="/matrix-v1/compliance-route" element={<PathA />} />
             <Route path="/matrix-v1/anomaly-route" element={<PathB />} />
             <Route path="/matrix-v1/map" element={<Map />} />

--- a/src/__tests__/MatrixV1GuardianCall.test.jsx
+++ b/src/__tests__/MatrixV1GuardianCall.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import GuardianCall from '../pages/matrix-v1/GuardianCall';
+
+function setup() {
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/guardian-call']}>
+      <Routes>
+        <Route path="/matrix-v1/guardian-call" element={<GuardianCall />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  if (Math.random.mockRestore) Math.random.mockRestore();
+});
+
+test('shows already linked message when flag set', () => {
+  localStorage.setItem('guardianLinked', 'true');
+  setup();
+  expect(screen.getByText(/already linked/i)).toBeInTheDocument();
+});
+
+test('offers retry after incorrect selection', async () => {
+  jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0.2);
+  setup();
+  const cells = screen.getAllByRole('button');
+  await userEvent.click(cells[2]);
+  await userEvent.click(cells[3]);
+  expect(await screen.findByRole('button', { name: /retry sync/i })).toBeInTheDocument();
+});

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,20 @@ code {
 .matrix-gradient-purple {
   @apply bg-gradient-to-br from-purple-700 to-fuchsia-600 text-white;
 }
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  75% { transform: translateX(4px); }
+}
+.animate-shake {
+  animation: shake 0.3s;
+}
+
+@keyframes flash-green {
+  0%, 100% { background-color: transparent; }
+  50% { background-color: rgba(16, 185, 129, 0.5); }
+}
+.flash-green {
+  animation: flash-green 0.5s;
+}

--- a/src/pages/matrix-v1/GuardianCall.jsx
+++ b/src/pages/matrix-v1/GuardianCall.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import MatrixRain from '../../components/MatrixRain';
+
+const GRID = 3;
+
+export default function GuardianCall() {
+  const [pair, setPair] = useState([]);
+  const [highlighted, setHighlighted] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const [status, setStatus] = useState('init'); // init, preview, select, success, fail
+  const [already, setAlready] = useState(false);
+  const [shake, setShake] = useState(false);
+  const [flash, setFlash] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem('guardianLinked') === 'true') {
+      setAlready(true);
+    } else {
+      startRound();
+    }
+  }, []);
+
+  const startRound = () => {
+    const total = GRID * GRID;
+    let first = Math.floor(Math.random() * total);
+    let second;
+    do {
+      second = Math.floor(Math.random() * total);
+    } while (second === first);
+    setPair([first, second]);
+    setSelected([]);
+    setStatus('preview');
+    setHighlighted([first, second]);
+    setTimeout(() => {
+      setHighlighted([]);
+      setStatus('select');
+    }, 1000);
+  };
+
+  const handleSelect = (idx) => {
+    if (status !== 'select' || selected.includes(idx) || already) return;
+    const newSel = [...selected, idx];
+    setSelected(newSel);
+    if (newSel.length === 2) {
+      const sorted = [...newSel].sort();
+      const target = [...pair].sort();
+      if (sorted[0] === target[0] && sorted[1] === target[1]) {
+        setFlash(true);
+        setStatus('success');
+        localStorage.setItem('guardianLinked', 'true');
+        setTimeout(() => setFlash(false), 500);
+      } else {
+        setStatus('fail');
+      }
+    }
+  };
+
+  const retry = () => {
+    setShake(true);
+    setTimeout(() => setShake(false), 400);
+    setSelected([]);
+    setStatus('preview');
+    setHighlighted(pair);
+    setTimeout(() => {
+      setHighlighted([]);
+      setStatus('select');
+    }, 1000);
+  };
+
+  const cells = [];
+  for (let i = 0; i < GRID * GRID; i++) {
+    const isH = highlighted.includes(i);
+    const isS = selected.includes(i);
+    cells.push(
+      <button
+        key={i}
+        onClick={() => handleSelect(i)}
+        disabled={already || status === 'success'}
+        className={`w-16 h-16 sm:w-20 sm:h-20 bg-gray-800 flex items-center justify-center border ${
+          isH ? 'matrix-glow-purple' : 'border-gray-600'
+        } ${isS ? 'matrix-glow-green' : ''}`}
+        data-testid={`cell-${i}`}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-400 font-mono space-y-6 relative overflow-hidden">
+      {typeof window !== 'undefined' && (
+        <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
+      )}
+      <div className="relative z-10 flex flex-col items-center space-y-4">
+        <h1 className="text-3xl font-bold">Synchronize with Guardian</h1>
+        <div className={`grid grid-cols-3 gap-2 p-4 ${flash ? 'flash-green' : ''} ${shake ? 'animate-shake' : ''}`}>{cells}</div>
+        <p className="text-sm text-green-200">Identify the sync points</p>
+        {status === 'success' && <p className="text-green-500">Guardian Link Established</p>}
+        {already && <p className="text-green-500">Already Linked</p>}
+        {status === 'fail' && !already && (
+          <button onClick={retry} className="mt-2 px-4 py-2 rounded bg-green-900 text-green-500 hover:bg-green-800">
+            Retry Sync
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add GuardianCall puzzle page
- wire GuardianCall route into the app
- style shake & flash grid animations
- test GuardianCall behavior

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm test --silent` *(fails: react-scripts not found)*