### PR TITLE
[brian_m] add matrix route memory module

### DIFF
--- a/src/__tests__/MatrixRouteMemory.test.js
+++ b/src/__tests__/MatrixRouteMemory.test.js
@@ -1,0 +1,27 @@
+import { saveVisited, getVisited, getCurrentNode, setCurrentNode, resetProgress } from '../utils/MatrixRouteMemory';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+test('tracks visited nodes', () => {
+  expect(getVisited()).toEqual([]);
+  saveVisited('a');
+  saveVisited('b');
+  saveVisited('a');
+  expect(getVisited()).toEqual(['a', 'b']);
+});
+
+test('stores current node', () => {
+  expect(getCurrentNode()).toBe('');
+  setCurrentNode('c');
+  expect(getCurrentNode()).toBe('c');
+});
+
+test('resetProgress clears all data', () => {
+  saveVisited('x');
+  setCurrentNode('y');
+  resetProgress();
+  expect(getVisited()).toEqual([]);
+  expect(getCurrentNode()).toBe('');
+});

--- a/src/utils/MatrixRouteMemory.js
+++ b/src/utils/MatrixRouteMemory.js
@@ -1,0 +1,42 @@
+const VISITED_KEY = 'matrixVisited';
+const NODE_KEY = 'matrixCurrentNode';
+
+export function getVisited() {
+  try {
+    const data = localStorage.getItem(VISITED_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveVisited(id) {
+  try {
+    const visited = getVisited();
+    if (!visited.includes(id)) {
+      visited.push(id);
+      localStorage.setItem(VISITED_KEY, JSON.stringify(visited));
+    }
+  } catch {}
+}
+
+export function getCurrentNode() {
+  try {
+    return localStorage.getItem(NODE_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function setCurrentNode(id) {
+  try {
+    localStorage.setItem(NODE_KEY, id);
+  } catch {}
+}
+
+export function resetProgress() {
+  try {
+    localStorage.removeItem(VISITED_KEY);
+    localStorage.removeItem(NODE_KEY);
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add MatrixRouteMemory util module using `localStorage`
- provide basic tests for the memory helper

## Testing
- `npm install` *(fails: react-scripts not found)*
- `npm test -- -t MatrixRouteMemory` *(fails: react-scripts not found)*