### PR TITLE
[brian_m] replace headings with MatrixRouteBanner

### DIFF
--- a/src/__tests__/MatrixRouteBanner.test.jsx
+++ b/src/__tests__/MatrixRouteBanner.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import MatrixRouteBanner from '../components/MatrixRouteBanner';
+
+test('renders title, subtitle, and status', () => {
+  render(<MatrixRouteBanner title="Title" subtitle="Sub" status="Active" />);
+  expect(screen.getByText(/Title/)).toBeInTheDocument();
+  expect(screen.getByText(/Sub/)).toBeInTheDocument();
+  expect(screen.getByText(/Active/)).toBeInTheDocument();
+});

--- a/src/components/EchoLoop.jsx
+++ b/src/components/EchoLoop.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import MatrixRain from './MatrixRain';
+import MatrixRouteBanner from './MatrixRouteBanner';
 
 export default function EchoLoop() {
   const navigate = useNavigate();
@@ -28,14 +29,13 @@ export default function EchoLoop() {
 
   return (
     <div
-      className={`min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-6 relative overflow-hidden ${shaking ? 'shake' : ''}`}
+      className={`min-h-screen flex flex-col bg-black text-green-500 font-mono relative overflow-hidden ${shaking ? 'shake' : ''}`}
     >
       {typeof window !== 'undefined' && (
         <MatrixRain zIndex={0} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} />
       )}
-      <div className="relative z-10 flex flex-col items-center space-y-6 w-full max-w-md px-4">
-        <h1 className="text-3xl font-bold">Echo System Diagnostic</h1>
-        <p className="text-lg text-center">Choose your path:</p>
+      <MatrixRouteBanner title="Echo System Diagnostic" subtitle="Choose your path:" status="🧠 Active" />
+      <div className="relative z-10 flex-1 flex flex-col items-center justify-center space-y-6 w-full max-w-md px-4">
         <div className="flex space-x-4">
           <button onClick={() => handleSelect('A')} className="px-4 py-2 rounded bg-green-900 text-green-500 hover:bg-green-800 transition-colors">Option A</button>
           <button onClick={() => handleSelect('B')} className="px-4 py-2 rounded bg-yellow-900 text-yellow-500 hover:bg-yellow-800 transition-colors">Option B</button>

--- a/src/components/MatrixRouteBanner.jsx
+++ b/src/components/MatrixRouteBanner.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function MatrixRouteBanner({ title, subtitle, status }) {
+  return (
+    <div className="w-full bg-gray-900 text-green-400 px-4 py-2 shadow-md flex flex-col items-center">
+      <h1 className="text-xl font-bold text-green-500">{title}</h1>
+      {subtitle && <p className="text-sm">{subtitle}</p>}
+      {status && <span className="text-xs mt-1">{status}</span>}
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/GuardianCall.jsx
+++ b/src/pages/matrix-v1/GuardianCall.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import MatrixRouteBanner from '../../components/MatrixRouteBanner';
 
 export default function GuardianCall({ testSequence }) {
   const navigate = useNavigate();
@@ -77,11 +78,13 @@ export default function GuardianCall({ testSequence }) {
   const squares = [0, 1, 2, 3];
   const attempt = Math.min(userInput.length + 1, sequence.length);
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-4">
-      <div className="bg-gray-800 px-4 py-2 rounded shadow-md text-center space-y-1">
-        <h1 className="text-xl font-bold">Synchronize with Guardian</h1>
-        <div className="text-sm text-green-400">Attempt {attempt} of {sequence.length}</div>
-      </div>
+    <div className="min-h-screen flex flex-col bg-black text-green-500 font-mono relative">
+      <MatrixRouteBanner
+        title="Synchronize with Guardian"
+        subtitle={`Attempt ${attempt} of ${sequence.length}`}
+        status="🧠 Active"
+      />
+      <div className="flex-1 flex flex-col items-center justify-center space-y-4">
       <div className={`grid grid-cols-2 gap-4 ${shake ? 'animate-shake' : ''} ${successFlash ? 'animate-flash-green' : ''}`}>
         {squares.map((sq) => (
           <div
@@ -106,6 +109,7 @@ export default function GuardianCall({ testSequence }) {
           Retry Synchronization
         </button>
       )}
+      </div>
     </div>
   );
 }

--- a/src/pages/matrix-v1/Stabilize.jsx
+++ b/src/pages/matrix-v1/Stabilize.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import MatrixRouteBanner from '../../components/MatrixRouteBanner';
 
 export default function Stabilize({ testSequence }) {
   const navigate = useNavigate();
@@ -77,11 +78,13 @@ export default function Stabilize({ testSequence }) {
 
   const squares = [0, 1, 2, 3];
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-green-500 font-mono space-y-4">
-      <div className="bg-gray-800 px-4 py-2 rounded shadow-md text-center space-y-1">
-        <h1 className="text-xl font-bold">Stabilize the System</h1>
-        <div className="text-sm text-green-400">Sequence: {userInput.length} of {sequence.length}</div>
-      </div>
+    <div className="min-h-screen flex flex-col bg-black text-green-500 font-mono relative">
+      <MatrixRouteBanner
+        title="Stabilize the System"
+        subtitle={`Sequence: ${userInput.length} of ${sequence.length}`}
+        status="🧠 Active"
+      />
+      <div className="flex-1 flex flex-col items-center justify-center space-y-4">
       <div className={`grid grid-cols-2 gap-4 ${shake ? 'animate-shake' : ''} ${successFlash ? 'animate-flash-green' : ''}`}>
         {squares.map((sq) => (
           <div
@@ -106,6 +109,7 @@ export default function Stabilize({ testSequence }) {
           Try another sequence
         </button>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add new `MatrixRouteBanner` component for scene headers
- use banner in `Stabilize`, `GuardianCall`, and `EchoLoop`
- create tests for new banner component

## Testing
- `npm test` *(fails: react-scripts not found)*