### PR TITLE
[brian_m] Restore GuardianCall puzzle logic

### DIFF
--- a/src/__tests__/MatrixV1GuardianCall.test.jsx
+++ b/src/__tests__/MatrixV1GuardianCall.test.jsx
@@ -25,23 +25,39 @@ test('redirects to terminal without access', () => {
   expect(screen.getByText(/terminal/i)).toBeInTheDocument();
 });
 
-test('shows success after correct input', () => {
+test('shows success after selecting correct tiles', () => {
   jest.useFakeTimers();
-  setup(true, [0]);
+  setup(true, [0, 1]);
   act(() => {
     jest.advanceTimersByTime(1500);
   });
   userEvent.click(screen.getByRole('button', { name: /square-0/i }));
-  expect(screen.getByText(/guardian synchronized/i)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /retry synchronization/i })).toBeInTheDocument();
+  userEvent.click(screen.getByRole('button', { name: /square-1/i }));
+  expect(screen.getByText(/guardian link established/i)).toBeInTheDocument();
+  expect(localStorage.getItem('guardianLinked')).toBe('true');
 });
 
-test('shows try again on wrong input', () => {
+test('shows retry option on wrong input', () => {
   jest.useFakeTimers();
-  setup(true, [1]);
+  setup(true, [0, 1]);
   act(() => {
     jest.advanceTimersByTime(1500);
   });
   userEvent.click(screen.getByRole('button', { name: /square-0/i }));
+  userEvent.click(screen.getByRole('button', { name: /square-2/i }));
   expect(screen.getByText(/try again/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+});
+
+test('skips puzzle if already linked', () => {
+  localStorage.setItem('matrixV1Access', 'true');
+  localStorage.setItem('guardianLinked', 'true');
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/guardian-call']}>
+      <Routes>
+        <Route path="/matrix-v1/guardian-call" element={<GuardianCall />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/already linked/i)).toBeInTheDocument();
 });

--- a/src/pages/matrix-v1/GuardianCall.jsx
+++ b/src/pages/matrix-v1/GuardianCall.jsx
@@ -4,13 +4,16 @@ import MatrixRouteBanner from '../../components/MatrixRouteBanner';
 
 export default function GuardianCall({ testSequence }) {
   const navigate = useNavigate();
-  const [sequence, setSequence] = useState([]);
-  const [userInput, setUserInput] = useState([]);
-  const [active, setActive] = useState(null);
+  const [sequence, setSequence] = useState([]); // two tile indexes
+  const [highlighted, setHighlighted] = useState([]); // tiles shown during preview
+  const [userInput, setUserInput] = useState([]); // tiles clicked by user
   const [inputEnabled, setInputEnabled] = useState(false);
   const [message, setMessage] = useState('');
   const [shake, setShake] = useState(false);
   const [successFlash, setSuccessFlash] = useState(false);
+  const [showRetry, setShowRetry] = useState(false);
+
+  const alreadyLinked = localStorage.getItem('guardianLinked') === 'true';
 
   useEffect(() => {
     if (localStorage.getItem('matrixV1Access') !== 'true') {
@@ -18,97 +21,106 @@ export default function GuardianCall({ testSequence }) {
     }
   }, [navigate]);
 
-  const playPreview = useCallback((seq) => {
+  const randomPair = () => {
+    const options = Array.from({ length: 9 }, (_, i) => i);
+    const first = options.splice(Math.floor(Math.random() * options.length), 1)[0];
+    const second = options[Math.floor(Math.random() * options.length)];
+    return [first, second];
+  };
+
+  const preview = useCallback((seq) => {
     setInputEnabled(false);
-    let i = 0;
-    function flash() {
-      setActive(seq[i]);
-      setTimeout(() => {
-        setActive(null);
-        i += 1;
-        if (i < seq.length) {
-          setTimeout(flash, 400);
-        } else {
-          setTimeout(() => {
-            setInputEnabled(true);
-          }, 400);
-        }
-      }, 300);
-    }
-    flash();
+    setHighlighted(seq);
+    setTimeout(() => {
+      setHighlighted([]);
+      setInputEnabled(true);
+    }, 1500);
   }, []);
 
   const startRound = useCallback(() => {
-    const len = testSequence ? testSequence.length : Math.floor(Math.random() * 3) + 3;
-    const seq = testSequence || Array.from({ length: len }, () => Math.floor(Math.random() * 4));
+    const seq = testSequence || randomPair();
     setSequence(seq);
     setUserInput([]);
     setSuccessFlash(false);
+    setShowRetry(false);
     setMessage('');
-    playPreview(seq);
-  }, [playPreview, testSequence]);
+    preview(seq);
+  }, [preview, testSequence]);
 
   useEffect(() => {
-    startRound();
-  }, [startRound]);
+    if (!alreadyLinked) {
+      startRound();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleSelect = (index) => {
-    if (!inputEnabled) return;
-    const next = userInput.length;
-    if (sequence[next] === index) {
-      const updated = [...userInput, index];
-      setUserInput(updated);
-      if (updated.length === sequence.length) {
-        setInputEnabled(false);
-        setSuccessFlash(true);
-        setMessage('Guardian synchronized');
-      }
-    } else {
+    if (!inputEnabled || userInput.includes(index)) return;
+    const updated = [...userInput, index];
+    setUserInput(updated);
+    if (updated.length === 2) {
       setInputEnabled(false);
-      setShake(true);
-      setMessage('Try Again');
-      setTimeout(() => {
-        setShake(false);
-        setMessage('');
-        startRound();
-      }, 700);
+      const sortedInput = [...updated].sort();
+      const sortedSeq = [...sequence].sort();
+      if (sortedInput[0] === sortedSeq[0] && sortedInput[1] === sortedSeq[1]) {
+        setSuccessFlash(true);
+        setMessage('Guardian Link Established');
+        localStorage.setItem('guardianLinked', 'true');
+      } else {
+        setShake(true);
+        setMessage('Try Again');
+        setShowRetry(true);
+        setTimeout(() => setShake(false), 500);
+      }
     }
   };
 
-  const squares = [0, 1, 2, 3];
-  const attempt = Math.min(userInput.length + 1, sequence.length);
+  const tiles = Array.from({ length: 9 }, (_, i) => i);
+
   return (
     <div className="min-h-screen flex flex-col bg-black text-green-500 font-mono relative">
       <MatrixRouteBanner
         title="Synchronize with Guardian"
-        subtitle={`Attempt ${attempt} of ${sequence.length}`}
+        subtitle="Identify the sync points"
         status="🧠 Active"
       />
-      <div className="mt-8 flex-1 flex flex-col items-center justify-center min-h-[60vh] space-y-4">
-      <div className={`grid grid-cols-2 gap-4 ${shake ? 'animate-shake' : ''} ${successFlash ? 'animate-flash-green' : ''}`}>
-        {squares.map((sq) => (
-          <div
-            key={sq}
-            role="button"
-            aria-label={`square-${sq}`}
-            onClick={() => handleSelect(sq)}
-            className={`w-20 h-20 border-2 border-green-500 transition-all ${active === sq ? 'bg-green-400 animate-glow-green' : 'bg-gray-800'} ${inputEnabled ? 'cursor-pointer hover:brightness-110 active:scale-95' : ''}`}
-          />
-        ))}
-      </div>
-      <div className="h-6 text-center">
-        {message && (
-          <p className={`${successFlash ? 'text-green-400 animate-pulse' : 'text-red-400'}`}>{message}</p>
+      <div className="mt-8 flex flex-col items-center min-h-[60vh]">
+        {alreadyLinked ? (
+          <p className="text-green-400 text-xl">Already Linked</p>
+        ) : (
+          <>
+            <div
+              className={`grid grid-cols-3 gap-4 ${shake ? 'animate-shake' : ''} ${
+                successFlash ? 'animate-flash-green' : ''
+              }`}
+            >
+              {tiles.map((t) => (
+                <div
+                  key={t}
+                  role="button"
+                  aria-label={`square-${t}`}
+                  onClick={() => handleSelect(t)}
+                  className={`w-16 h-16 border-2 border-green-500 transition-all ${
+                    highlighted.includes(t) ? 'bg-green-400 animate-glow-green' : 'bg-gray-800'
+                  } ${inputEnabled ? 'cursor-pointer hover:brightness-110 active:scale-95' : ''}`}
+                />
+              ))}
+            </div>
+            <div className="h-6 text-center">
+              {message && (
+                <p className={`${successFlash ? 'text-green-400 animate-pulse' : 'text-red-400'}`}>{message}</p>
+              )}
+            </div>
+            {showRetry && (
+              <button
+                onClick={startRound}
+                className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600"
+              >
+                Retry
+              </button>
+            )}
+          </>
         )}
-      </div>
-      {successFlash && (
-        <button
-          onClick={startRound}
-          className="px-4 py-2 rounded bg-green-700 text-black hover:bg-green-600"
-        >
-          Retry Synchronization
-        </button>
-      )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- overhaul GuardianCall to highlight a random pair of tiles
- persist guardian link and skip puzzle when already linked
- update puzzle tests for new behavior
- tweak layout spacing as requested

## Testing
- `npm test` *(fails: react-scripts not found)*