### PR TITLE
[brian_m] fix overlay layout crash

### DIFF
--- a/src/pages/matrix-v1/MapCanvas.jsx
+++ b/src/pages/matrix-v1/MapCanvas.jsx
@@ -227,9 +227,10 @@ function MapCanvasInner({ nodes }) {
 
   const overlayNodes = useMemo(() => {
     const visibleNodes = getVisibleOverlayNodes();
+    const laidOut = layoutNodesByDepth(visibleNodes);
     const focusedNodeSet = focusedOverlayNodeId ? getDownstreamNodes(focusedOverlayNodeId) : null;
-    
-    return visibleNodes.map(node => ({
+
+    return laidOut.map(node => ({
       ...node,
       className: focusedNodeSet && !focusedNodeSet.has(node.id) ? 'opacity-30' : '',
       data: {


### PR DESCRIPTION
## Summary
- ensure overlay nodes in the Matrix map get layout positions before rendering

## Testing
- `npm test --silent` *(fails: react-scripts not found)*