### PR TITLE
[brian_m] implement world content hook

### DIFF
--- a/src/content/worlds.json
+++ b/src/content/worlds.json
@@ -1,0 +1,18 @@
+{
+  "matrix": {
+    "matrix-pill-choice": {
+      "title": "This is your last chance, {name}.",
+      "dialogue": "After this, there is no going back. You take the blue pill - the story ends, you wake up in your bed and believe whatever you want to believe. You take the red pill - you stay in Wonderland, and I show you how deep the rabbit hole goes.",
+      "summary": "Morpheus presents the iconic red vs blue pill decision.",
+      "options": ["Red Pill", "Blue Pill"]
+    }
+  },
+  "witcher": {
+    "matrix-pill-choice": {
+      "title": "A Witcher's Choice",
+      "dialogue": "Will you accept the contract that ties you to destiny, or walk away to follow your own path?",
+      "summary": "Geralt must decide whether to follow destiny.",
+      "options": ["Accept", "Decline"]
+    }
+  }
+}

--- a/src/hooks/useWorldContent.js
+++ b/src/hooks/useWorldContent.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import worlds from '../content/worlds.json';
+import { useContentStore } from '../store/useContentStore';
+
+/**
+ * Retrieve world-aware content for a given node id.
+ * Content is cached via Zustand so repeated calls are inexpensive.
+ *
+ * @param {string} world - active world key (e.g. "matrix", "witcher")
+ * @param {string} nodeId - story node identifier
+ * @returns {object} content fields like { title, dialogue, summary, options }
+ */
+export function useWorldContent(world = 'matrix', nodeId) {
+  const cached = useContentStore((s) => s.worldContent[world]);
+  const setWorldContent = useContentStore((s) => s.setWorldContent);
+
+  // Load content for the requested world the first time it's used
+  useEffect(() => {
+    if (!cached) {
+      // TODO: replace static import with fetch from CMS/Sheets
+      setWorldContent(world, worlds[world] || {});
+    }
+  }, [world, cached, setWorldContent]);
+
+  const worldData = cached || worlds[world] || {};
+  const defaultData = worlds['matrix'] || {};
+  return worldData[nodeId] || defaultData[nodeId] || {};
+}

--- a/src/pages/matrix-v1/Entry.jsx
+++ b/src/pages/matrix-v1/Entry.jsx
@@ -5,12 +5,16 @@ import NPC from './components/NPC';
 import useTypewriterEffect from '../../components/useTypewriterEffect';
 import { useStoryProgress } from '../../hooks/useStoryProgress';
 import { useAppStore } from '../../store/useAppStore';
+import { useTheme } from '../../theme/ThemeContext';
+import { useWorldContent } from '../../hooks/useWorldContent';
 
 export default function Entry() {
   const [showChoice, setShowChoice] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const userName = useAppStore((state) => state.user.name);
+  const { currentWorld } = useTheme();
+  const { title, dialogue, options } = useWorldContent(currentWorld, 'matrix-pill-choice');
   
   // Check if user came from name prompt with a name
   const hasName = userName || localStorage.getItem('matrixV1Name') || location.state?.name;
@@ -71,11 +75,11 @@ export default function Entry() {
         {showChoice && (
           <>
             <h2 className="text-2xl font-bold heading-theme">
-              This is your last chance, {hasName}.
+              {title?.replace('{name}', hasName)}
             </h2>
-            
+
             <NPC type="mentor" speaker="morpheus">
-              "After this, there is no going back. You take the blue pill - the story ends, you wake up in your bed and believe whatever you want to believe. You take the red pill - you stay in Wonderland, and I show you how deep the rabbit hole goes."
+              {dialogue}
             </NPC>
 
             <div className="space-y-4">
@@ -86,16 +90,16 @@ export default function Entry() {
                 className="w-full"
                 ariaLabel="Take the red pill - Enter the Matrix"
               >
-                🔴 Red Pill
+                {options?.[0] || 'Red Pill'}
               </MatrixButton>
-              <MatrixButton 
-                onClick={blue} 
-                variant="info" 
+              <MatrixButton
+                onClick={blue}
+                variant="info"
                 size="lg"
                 className="w-full"
                 ariaLabel="Take the blue pill - Return to normal world"
               >
-                🔵 Blue Pill
+                {options?.[1] || 'Blue Pill'}
               </MatrixButton>
             </div>
           </>

--- a/src/store/useContentStore.js
+++ b/src/store/useContentStore.js
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+/**
+ * Simple store for caching world content by key.
+ * In the future content may be loaded from an external CMS.
+ */
+export const useContentStore = create((set) => ({
+  worldContent: {},
+  setWorldContent: (world, content) =>
+    set((state) => ({
+      worldContent: { ...state.worldContent, [world]: content }
+    }))
+}));


### PR DESCRIPTION
## Summary
- add useWorldContent() hook for retrieving world-specific story content
- cache content per world with a new Zustand store
- store example text in `worlds.json`
- update Matrix entry page to use the hook

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683df2f33590832681e17b31924b117b