### PR TITLE
[brian_m] enhance MapD3 visuals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,6 +86,14 @@ code {
     filter: drop-shadow(0 0 8px currentColor);
   }
 
+  /* Improved label readability for SVG text */
+  .node-label {
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+    paint-order: stroke fill;
+    stroke: #000;
+    stroke-width: 0.5px;
+  }
+
   /* Better button transitions */
   .expand-button {
     transition: all 200ms ease-in-out;

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -172,6 +172,7 @@ export default function MapD3() {
   const [statusFilter, setStatusFilter] = useState(['live', 'wip', 'stub']);
   const [selectedNode, setSelectedNode] = useState(null);
   const [breadcrumb, setBreadcrumb] = useState([]);
+  const [initialCentered, setInitialCentered] = useState(false);
   
   // 🛠 DEBUGGING: Temporarily expand ALL nodes instead of using getInitialExpandedNodes()
   // TODO: Revert to: useState(getInitialExpandedNodes(realMatrixNodes, realMatrixEdges))
@@ -479,7 +480,7 @@ export default function MapD3() {
     }
   }, [toggleNodeExpansion, originalTree]);
 
-  const { drawTree } = useTreeLayout({
+  const { drawTree, rootPosRef } = useTreeLayout({
     svgRef,
     filteredTree,
     layoutType,
@@ -543,6 +544,22 @@ export default function MapD3() {
   useEffect(() => {
     drawTree();
   }, [drawTree]);
+
+  useEffect(() => {
+    if (!initialCentered && rootPosRef?.current && svgRef.current) {
+      const { x, y } = rootPosRef.current;
+      const svgRect = svgRef.current.getBoundingClientRect();
+      const centerX = svgRect.width / 2;
+      const centerY = svgRect.height / 2;
+      d3.select(svgRef.current)
+        .transition()
+        .call(
+          d3.zoom().transform,
+          d3.zoomIdentity.translate(centerX - x, centerY - y).scale(1)
+        );
+      setInitialCentered(true);
+    }
+  }, [rootPosRef, initialCentered]);
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-white flex">


### PR DESCRIPTION
## Summary
- tune node spacing for tree, cluster and radial layouts
- add interactive network layout with dragging and pinning
- center map on root node on first render
- improve label readability

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f16c3e8448326b440347599778563