### PR TITLE
[brian_m] Add oracle dialogue hook and component

### DIFF
--- a/src/__tests__/UseOracleDialogue.test.js
+++ b/src/__tests__/UseOracleDialogue.test.js
@@ -1,0 +1,8 @@
+import { renderHook } from '@testing-library/react';
+import { useOracleDialogue } from '../hooks/useOracleDialogue';
+
+test('returns oracle dialogue for node', () => {
+  const { result } = renderHook(() => useOracleDialogue('matrix-oracle-seekers'));
+  expect(result.current.dialogue).toHaveLength(2);
+  expect(result.current.options[0].prompt).toMatch(/Ask about the future/);
+});

--- a/src/components/OracleDialogue.jsx
+++ b/src/components/OracleDialogue.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { CharacterDialogue } from './CharacterSystem';
+import { useOracleDialogue } from '../hooks/useOracleDialogue';
+
+/**
+ * Display an oracle dialogue sequence from worlds.json.
+ */
+export default function OracleDialogue({ nodeId = 'matrix-oracle-seekers' }) {
+  const { dialogue, options } = useOracleDialogue(nodeId);
+
+  return (
+    <div className="space-y-4">
+      {dialogue.map((line, idx) => (
+        <CharacterDialogue
+          key={idx}
+          characterKey="oracle"
+          text={line.text}
+          className={line.tone === 'cryptic' ? 'italic' : ''}
+        />
+      ))}
+      {options.length > 0 && (
+        <div className="mt-4 space-y-2 text-sm">
+          {options.map((opt, i) => (
+            <div key={i} className="text-blue-300">
+              {opt.prompt}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/content/worlds.json
+++ b/src/content/worlds.json
@@ -14,5 +14,17 @@
       "summary": "Geralt must decide whether to follow destiny.",
       "options": ["Accept", "Decline"]
     }
+  },
+  "oracle": {
+    "matrix-oracle-seekers": {
+      "dialogue": [
+        { "text": "You\u2019ve felt it your whole life...", "tone": "cryptic" },
+        { "text": "Not everyone is ready to hear what you already know.", "tone": "soft" }
+      ],
+      "options": [
+        { "prompt": "Ask about the future", "outcome": "prophecy", "condition": "karma >= 2" },
+        { "prompt": "Reject her words", "outcome": "glitch-path" }
+      ]
+    }
   }
 }

--- a/src/hooks/useOracleDialogue.js
+++ b/src/hooks/useOracleDialogue.js
@@ -1,0 +1,13 @@
+import { useWorldContent } from './useWorldContent';
+
+/**
+ * Retrieve oracle dialogue sequences for a given node.
+ * Wraps useWorldContent with the "oracle" world key.
+ *
+ * @param {string} nodeId - dialogue node identifier
+ * @returns {{dialogue: Array, options: Array}}
+ */
+export function useOracleDialogue(nodeId) {
+  const { dialogue = [], options = [] } = useWorldContent('oracle', nodeId);
+  return { dialogue, options };
+}


### PR DESCRIPTION
## Summary
- extend `worlds.json` with new oracle dialogue example
- add `useOracleDialogue` hook
- provide `OracleDialogue` component to display lines
- test oracle dialogue hook

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1e5428dc83269bf1f8cadf890ff5