### PR TITLE
[brian_m] add light/dark mode toggle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 
 import { UserProvider } from './components/UserContext';
 import { ThemeProvider } from './theme/ThemeContext';
+import { ColorModeProvider } from './theme/ColorModeContext';
 
 import Navigation from './components/Navigation';
 import Breadcrumbs from './components/Breadcrumbs';
@@ -73,7 +74,8 @@ export default function App() {
   return (
     <UserProvider>
       <ThemeProvider>
-        <Router>
+        <ColorModeProvider>
+          <Router>
           <div className="min-h-screen bg-theme-primary text-theme-primary pt-20 pb-4 relative font-theme-ui">
             <Navigation />
             <Breadcrumbs />
@@ -146,7 +148,8 @@ export default function App() {
               <Route path="*" element={<Navigate to="/" />} />
             </Routes>
           </div>
-        </Router>
+          </Router>
+        </ColorModeProvider>
       </ThemeProvider>
     </UserProvider>
   );

--- a/src/__tests__/ColorModeToggle.test.jsx
+++ b/src/__tests__/ColorModeToggle.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ColorModeToggle from '../components/ColorModeToggle';
+import { ColorModeProvider } from '../theme/ColorModeContext';
+
+function setup() {
+  render(
+    <ColorModeProvider>
+      <ColorModeToggle />
+    </ColorModeProvider>
+  );
+}
+
+test('toggles light and dark modes', async () => {
+  setup();
+  const button = screen.getByRole('button', { name: /toggle dark mode/i });
+  expect(document.documentElement.getAttribute('data-color-mode')).toBe('dark');
+  await userEvent.click(button);
+  expect(document.documentElement.getAttribute('data-color-mode')).toBe('light');
+});

--- a/src/components/ColorModeToggle.jsx
+++ b/src/components/ColorModeToggle.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { FaMoon, FaSun } from 'react-icons/fa';
+import { useColorMode } from '../theme/ColorModeContext';
+
+const ColorModeToggle = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  return (
+    <button
+      onClick={toggleColorMode}
+      aria-label="Toggle dark mode"
+      className="p-2 rounded-full border border-gray-300 bg-white text-gray-800 shadow"
+    >
+      {colorMode === 'dark' ? <FaSun /> : <FaMoon />}
+    </button>
+  );
+};
+
+export default ColorModeToggle;

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import UserIcon from './UserIcon';
 import ThemeToggle from './ThemeToggle';
+import ColorModeToggle from './ColorModeToggle';
 import { useTheme } from '../theme/ThemeContext';
 import {
   FaRoad,
@@ -69,8 +70,9 @@ export default function Navigation() {
             </div>
           </div>
           
-          {/* Theme Toggle - Positioned to allow dropdown overflow */}
-          <div className="relative">
+          {/* Mode and Theme Toggles */}
+          <div className="flex items-center gap-2 relative">
+            <ColorModeToggle />
             <ThemeToggle />
           </div>
         </nav>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,6 @@
 @import './theme/global-theme.css';
 
 :root {
-  color-scheme: dark;
 }
 
 body {
@@ -16,8 +15,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #111827;
-  color: white;
+
 }
 
 code {

--- a/src/theme/ColorModeContext.jsx
+++ b/src/theme/ColorModeContext.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+const ColorModeContext = createContext();
+
+export const useColorMode = () => {
+  const ctx = useContext(ColorModeContext);
+  if (!ctx) throw new Error('useColorMode must be used within a ColorModeProvider');
+  return ctx;
+};
+
+export const ColorModeProvider = ({ children }) => {
+  const getInitial = () => {
+    if (typeof window === 'undefined') return 'dark';
+    const stored = localStorage.getItem('color-mode');
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  };
+
+  const [colorMode, setColorMode] = useState(getInitial);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-color-mode', colorMode);
+    localStorage.setItem('color-mode', colorMode);
+  }, [colorMode]);
+
+  const toggleColorMode = useCallback(() => {
+    setColorMode(m => (m === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = { colorMode, setColorMode, toggleColorMode };
+  return (
+    <ColorModeContext.Provider value={value}>
+      {children}
+    </ColorModeContext.Provider>
+  );
+};

--- a/src/theme/global-theme.css
+++ b/src/theme/global-theme.css
@@ -1,5 +1,22 @@
 /* Global Theme Variables & Classes */
 
+
+/* Color mode styles */
+:root[data-color-mode='light'] {
+  color-scheme: light;
+}
+:root[data-color-mode='dark'] {
+  color-scheme: dark;
+}
+
+body[data-color-mode='light'] {
+  background: #f9fafb;
+  color: #111827;
+}
+body[data-color-mode='dark'] {
+  background: #111827;
+  color: white;
+}
 /* Base theme variables are injected by ThemeContext */
 :root {
   /* Default values - will be overridden by theme system */


### PR DESCRIPTION
## Summary
- add `ColorModeContext` for global light/dark mode
- implement `ColorModeToggle` UI and include it in navigation
- wire up provider in `App`
- support CSS for color modes and clean up `index.css`
- test the toggle

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f205f27ec83268eb46b482d5bbde2