### PR TITLE
[brian_m] refactor world backgrounds

### DIFF
--- a/src/__tests__/MatrixLayout.test.jsx
+++ b/src/__tests__/MatrixLayout.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider } from '../theme/ThemeContext';
 import MatrixLayout, { MatrixCard, MatrixButton, MatrixInput } from '../components/MatrixLayout';
+import { themes } from '../theme/themes';
 
 // Mock MatrixRain to avoid canvas issues in tests
 jest.mock('../components/MatrixRain', () => {
@@ -74,8 +75,21 @@ describe('MatrixLayout', () => {
         </MatrixLayout>
       </TestWrapper>
     );
-    
+
     expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  test('uses theme background when none provided', () => {
+    const { container } = render(
+      <TestWrapper>
+        <MatrixLayout>
+          <div>Test</div>
+        </MatrixLayout>
+      </TestWrapper>
+    );
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveStyle(`background: ${themes.matrix.background}`);
   });
 });
 

--- a/src/__tests__/WorldLayout.test.jsx
+++ b/src/__tests__/WorldLayout.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '../theme/ThemeContext';
+import WorldLayout from '../components/WorldLayout';
+import { themes } from '../theme/themes';
+
+const Wrapper = ({ children }) => (
+  <ThemeProvider>
+    {children}
+  </ThemeProvider>
+);
+
+test('renders children with world background', () => {
+  const { container } = render(
+    <Wrapper>
+      <WorldLayout>
+        <div>World Content</div>
+      </WorldLayout>
+    </Wrapper>
+  );
+
+  expect(screen.getByText('World Content')).toBeInTheDocument();
+  expect(container.firstChild).toHaveStyle(`background: ${themes.matrix.background}`);
+});

--- a/src/components/MatrixLayout.jsx
+++ b/src/components/MatrixLayout.jsx
@@ -10,19 +10,20 @@ export default function MatrixLayout({
   centered = true,
   fullHeight = true,
   glitch = false,
-  background = 'bg-black'
+  background
 }) {
-  const { currentTheme } = useTheme();
-  
+  const { theme } = useTheme();
+
   const baseClasses = [
     fullHeight ? 'min-h-screen' : '',
-    background,
     'font-mono',
     'relative',
     'overflow-hidden',
     'text-theme-primary',
     className
   ].filter(Boolean).join(' ');
+
+  const style = { background: background || theme.background };
 
   const contentClasses = [
     'relative',
@@ -36,7 +37,7 @@ export default function MatrixLayout({
   ].filter(Boolean).join(' ');
 
   return (
-    <div className={baseClasses}>
+    <div className={baseClasses} style={style}>
       {/* Matrix Rain Background */}
       {withRain && typeof window !== 'undefined' && (
         <MatrixRain 

--- a/src/components/WorldLayout.jsx
+++ b/src/components/WorldLayout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeContext';
+
+export default function WorldLayout({ children, className = '', ...props }) {
+  const { theme } = useTheme();
+  const classes = ['min-h-screen', 'relative', className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes} style={{ background: theme.background }} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/theme/global-theme.css
+++ b/src/theme/global-theme.css
@@ -9,13 +9,19 @@
   color-scheme: dark;
 }
 
+body[data-color-mode='light'],
+body[data-color-mode='dark'] {
+  background: var(--world-background);
+}
 body[data-color-mode='light'] {
-  background: #f9fafb;
   color: #111827;
 }
 body[data-color-mode='dark'] {
-  background: #111827;
   color: white;
+}
+
+body {
+  background: var(--world-background);
 }
 /* Base theme variables are injected by ThemeContext */
 :root {
@@ -252,16 +258,10 @@ body[data-color-mode='dark'] {
 }
 
 /* Theme-specific body classes for global styling */
-body.theme-matrix {
-  background: linear-gradient(135deg, #000000 0%, #001100 50%, #000000 100%);
-}
-
-body.theme-witcher {
-  background: linear-gradient(135deg, #2c1810 0%, #4f2f1f 50%, #2c1810 100%);
-}
-
+body.theme-matrix,
+body.theme-witcher,
 body.theme-nightcity {
-  background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 25%, #16213e 75%, #0f0f23 100%);
+  background: var(--world-background);
 }
 
 /* Theme-aware animations */

--- a/src/theme/themes.js
+++ b/src/theme/themes.js
@@ -2,6 +2,7 @@ export const themes = {
   matrix: {
     name: 'Matrix',
     id: 'matrix',
+    background: '#000',
     colors: {
       // Background colors
       primary: '#000000',
@@ -70,6 +71,7 @@ export const themes = {
   witcher: {
     name: 'Witcher',
     id: 'witcher',
+    background: '#f0f4f9',
     colors: {
       // Background colors
       primary: '#2c1810',
@@ -138,6 +140,7 @@ export const themes = {
   nightcity: {
     name: 'Night City',
     id: 'nightcity',
+    background: '#1a1a2e',
     colors: {
       // Background colors
       primary: '#0f0f23',
@@ -229,7 +232,12 @@ export const getThemeVariables = (themeId) => {
   Object.entries(theme.d3).forEach(([key, value]) => {
     variables[`--d3-${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`] = value;
   });
-  
+
+  // Background for world
+  if (theme.background) {
+    variables['--world-background'] = theme.background;
+  }
+
   return variables;
 };
 


### PR DESCRIPTION
## Summary
- theme config: add `background` for worlds
- expose `--world-background` in CSS variables
- set body background using theme variables
- update MatrixLayout to use theme background
- add sample WorldLayout component
- expand tests for MatrixLayout and add WorldLayout tests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f25ee76208326ac4015c2c4f148f8