### PR TITLE
[brian_m] add world-specific backgrounds

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 
 import { UserProvider } from './components/UserContext';
-import { ThemeProvider } from './theme/ThemeContext';
+import { ThemeProvider, useTheme } from './theme/ThemeContext';
 import { ColorModeProvider } from './theme/ColorModeContext';
 
 import Navigation from './components/Navigation';
@@ -70,84 +70,94 @@ import WitcherEntry from './pages/witcher/WitcherEntry';
 import MutationChoice from './pages/witcher/MutationChoice';
 import SignTraining from './pages/witcher/SignTraining';
 
+function AppLayout() {
+  const { currentWorld } = useTheme();
+
+  return (
+    <div
+      className={`min-h-screen bg-theme-primary text-theme-primary pt-20 pb-4 relative font-theme-ui world-background-${currentWorld}`}
+    >
+      <Navigation />
+      <Breadcrumbs />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/snack-trail" element={<SnackTrailPage />} />
+        <Route path="/pixel-art" element={<PixelArtMaker />} />
+        <Route path="/robot-lab" element={<RobotLab />} />
+        <Route path="/lego-build" element={<LegoBuildMode />} />
+        <Route path="/lego-inventory" element={<LegoInventory />} />
+        <Route path="/rc-plane" element={<RCPlaneDesigner />} />
+        <Route path="/little-alchemy" element={<LittleAlchemy />} />
+        <Route path="/updates" element={<Updates />} />
+
+        {/* Matrix V1 Routes */}
+        <Route path="/matrix-v1" element={<Entry />} />
+        <Route path="/matrix-v1/name-prompt" element={<MatrixNamePrompt />} />
+        <Route path="/matrix-v1/terminal" element={<Terminal />} />
+        <Route path="/matrix-v1/checkpoint" element={<Checkpoint />} />
+        <Route path="/matrix-v1/message" element={<Message />} />
+        <Route path="/matrix-v1/puzzle" element={<Puzzle />} />
+        <Route path="/matrix-v1/trace" element={<Trace />} />
+        <Route path="/matrix-v1/observer" element={<Observer />} />
+        <Route path="/matrix-v1/stage-1" element={<Stage1 />} />
+        <Route path="/matrix-v1/stage-2" element={<Stage2 />} />
+        <Route path="/matrix-v1/stage-3" element={<Stage3 />} />
+        <Route path="/matrix-v1/compliance-route" element={<PathA />} />
+        <Route path="/matrix-v1/anomaly-route" element={<PathB />} />
+        <Route path="/matrix-v1/map" element={<Map />} />
+        <Route path="/matrix-v1/map-d3" element={<MapD3 />} />
+        <Route path="/matrix-v1/quality-dashboard" element={<QualityDashboard />} />
+        <Route path="/matrix-v1/node-editor" element={<NodeEditor />} />
+        <Route path="/matrix-v1/deeper-profile" element={<DeeperProfile />} />
+        <Route path="/matrix-v1/interference" element={<Interference />} />
+        <Route path="/matrix-v1/stabilize" element={<Stabilize />} />
+        <Route path="/matrix-v1/guardian-call" element={<GuardianCall />} />
+        <Route path="/matrix-v1/path-b-glitch" element={<PathBGlitch />} />
+        <Route path="/matrix-v1/factions" element={<Factions />} />
+        <Route path="/matrix-v1/align-:slug" element={<Align />} />
+
+        {/* Faction Choice Routes */}
+        <Route path="/matrix-v1/faction-choice" element={<FactionChoice />} />
+        <Route path="/matrix-v1/zion-fleet" element={<ZionFleet />} />
+        <Route path="/matrix-v1/rebel-hackers" element={<RebelHackers />} />
+        <Route path="/matrix-v1/oracle-seekers" element={<OracleSeeker />} />
+
+        {/* Ghost Layer and Echo Fork Routes */}
+        <Route path="/matrix-v1/shard-init" element={<ShardInit />} />
+        <Route path="/matrix-v1/shard-insert" element={<ShardInsert />} />
+        <Route path="/matrix-v1/echo-loop" element={<EchoLoop />} />
+        <Route path="/matrix-v1/echo-verify" element={<EchoVerify />} />
+        <Route path="/matrix-v1/ghost-layer-2" element={<GhostLayer2 />} />
+
+        {/* New routes */}
+        <Route path="/matrix-v1/portal/factions" element={<FactionPortal />} />
+        <Route path="/matrix-v1/glitch-portal" element={<GlitchPortal />} />
+        <Route path="/matrix-v1/oracle-seekers" element={<OracleSeekers />} />
+
+        {/* Night City routes */}
+        <Route path="/matrix-v1/night-city/entry" element={<NightCityEntry />} />
+        <Route path="/matrix-v1/night-city/bouncer" element={<NightCityBouncer />} />
+
+        {/* Witcher routes */}
+        <Route path="/witcher/entry" element={<WitcherEntry />} />
+        <Route path="/witcher/mutation-choice" element={<MutationChoice />} />
+        <Route path="/witcher/sign-training" element={<SignTraining />} />
+
+        {/* Legacy Matrix Routes - Redirect to V1 */}
+        <Route path="/the-matrix/*" element={<Navigate to="/matrix-v1" replace />} />
+        <Route path="*" element={<Navigate to="/" />} />
+      </Routes>
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <UserProvider>
       <ThemeProvider>
         <ColorModeProvider>
           <Router>
-          <div className="min-h-screen bg-theme-primary text-theme-primary pt-20 pb-4 relative font-theme-ui">
-            <Navigation />
-            <Breadcrumbs />
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/snack-trail" element={<SnackTrailPage />} />
-              <Route path="/pixel-art" element={<PixelArtMaker />} />
-              <Route path="/robot-lab" element={<RobotLab />} />
-              <Route path="/lego-build" element={<LegoBuildMode />} />
-              <Route path="/lego-inventory" element={<LegoInventory />} />
-              <Route path="/rc-plane" element={<RCPlaneDesigner />} />
-              <Route path="/little-alchemy" element={<LittleAlchemy />} />
-              <Route path="/updates" element={<Updates />} />
-              
-              {/* Matrix V1 Routes */}
-              <Route path="/matrix-v1" element={<Entry />} />
-              <Route path="/matrix-v1/name-prompt" element={<MatrixNamePrompt />} />
-              <Route path="/matrix-v1/terminal" element={<Terminal />} />
-              <Route path="/matrix-v1/checkpoint" element={<Checkpoint />} />
-              <Route path="/matrix-v1/message" element={<Message />} />
-              <Route path="/matrix-v1/puzzle" element={<Puzzle />} />
-              <Route path="/matrix-v1/trace" element={<Trace />} />
-              <Route path="/matrix-v1/observer" element={<Observer />} />
-              <Route path="/matrix-v1/stage-1" element={<Stage1 />} />
-              <Route path="/matrix-v1/stage-2" element={<Stage2 />} />
-              <Route path="/matrix-v1/stage-3" element={<Stage3 />} />
-              <Route path="/matrix-v1/compliance-route" element={<PathA />} />
-              <Route path="/matrix-v1/anomaly-route" element={<PathB />} />
-              <Route path="/matrix-v1/map" element={<Map />} />
-              <Route path="/matrix-v1/map-d3" element={<MapD3 />} />
-              <Route path="/matrix-v1/quality-dashboard" element={<QualityDashboard />} />
-              <Route path="/matrix-v1/node-editor" element={<NodeEditor />} />
-              <Route path="/matrix-v1/deeper-profile" element={<DeeperProfile />} />
-              <Route path="/matrix-v1/interference" element={<Interference />} />
-              <Route path="/matrix-v1/stabilize" element={<Stabilize />} />
-              <Route path="/matrix-v1/guardian-call" element={<GuardianCall />} />
-              <Route path="/matrix-v1/path-b-glitch" element={<PathBGlitch />} />
-              <Route path="/matrix-v1/factions" element={<Factions />} />
-              <Route path="/matrix-v1/align-:slug" element={<Align />} />
-              
-              {/* Faction Choice Routes */}
-              <Route path="/matrix-v1/faction-choice" element={<FactionChoice />} />
-              <Route path="/matrix-v1/zion-fleet" element={<ZionFleet />} />
-              <Route path="/matrix-v1/rebel-hackers" element={<RebelHackers />} />
-              <Route path="/matrix-v1/oracle-seekers" element={<OracleSeeker />} />
-              
-              {/* Ghost Layer and Echo Fork Routes */}
-              <Route path="/matrix-v1/shard-init" element={<ShardInit />} />
-              <Route path="/matrix-v1/shard-insert" element={<ShardInsert />} />
-              <Route path="/matrix-v1/echo-loop" element={<EchoLoop />} />
-              <Route path="/matrix-v1/echo-verify" element={<EchoVerify />} />
-              <Route path="/matrix-v1/ghost-layer-2" element={<GhostLayer2 />} />
-              
-              {/* New routes */}
-              <Route path="/matrix-v1/portal/factions" element={<FactionPortal />} />
-              <Route path="/matrix-v1/glitch-portal" element={<GlitchPortal />} />
-              <Route path="/matrix-v1/oracle-seekers" element={<OracleSeekers />} />
-              
-              {/* Night City routes */}
-              <Route path="/matrix-v1/night-city/entry" element={<NightCityEntry />} />
-              <Route path="/matrix-v1/night-city/bouncer" element={<NightCityBouncer />} />
-              
-              {/* Witcher routes */}
-              <Route path="/witcher/entry" element={<WitcherEntry />} />
-              <Route path="/witcher/mutation-choice" element={<MutationChoice />} />
-              <Route path="/witcher/sign-training" element={<SignTraining />} />
-              
-              {/* Legacy Matrix Routes - Redirect to V1 */}
-              <Route path="/the-matrix/*" element={<Navigate to="/matrix-v1" replace />} />
-              <Route path="*" element={<Navigate to="/" />} />
-            </Routes>
-          </div>
+            <AppLayout />
           </Router>
         </ColorModeProvider>
       </ThemeProvider>

--- a/src/__tests__/AppWorldBackground.test.jsx
+++ b/src/__tests__/AppWorldBackground.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+// Basic test to ensure world background class is applied
+
+test('applies matrix world background by default', () => {
+  const { container } = render(<App />);
+  expect(container.querySelector('.world-background-matrix')).toBeInTheDocument();
+});

--- a/src/theme/global-theme.css
+++ b/src/theme/global-theme.css
@@ -264,6 +264,31 @@ body.theme-nightcity {
   background: var(--world-background);
 }
 
+/* World-specific root background classes */
+.world-background-matrix {
+  background-color: #000;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 255, 0, 0.05) 0%,
+    rgba(0, 255, 0, 0.05) 2px,
+    transparent 2px,
+    transparent 4px
+  );
+  background-size: 100% 4px;
+}
+
+.world-background-witcher {
+  background-image: linear-gradient(to bottom, #f4f6f8, #e8ecef);
+}
+
+.world-background-nightcity {
+  background-color: #0d0d1a;
+  background-image:
+    linear-gradient(0deg, rgba(255, 0, 255, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 255, 255, 0.15) 1px, transparent 1px);
+  background-size: 4px 4px;
+}
+
 /* Theme-aware animations */
 @keyframes matrix-glow {
   0%, 100% { filter: drop-shadow(0 0 5px var(--color-text-primary)); }


### PR DESCRIPTION
## Summary
- introduce `world-background-*` classes for Matrix, Witcher and Night City
- apply world background class based on `currentWorld` in `AppLayout`
- add regression test ensuring default Matrix background class

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f29fc0e7c8326b5ef2f0b513bbe4f