### PR TITLE
[brian_m] fix provider order

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -154,13 +154,13 @@ function AppLayout() {
 export default function App() {
   return (
     <UserProvider>
-      <ThemeProvider>
-        <ColorModeProvider>
+      <ColorModeProvider>
+        <ThemeProvider>
           <Router>
             <AppLayout />
           </Router>
-        </ColorModeProvider>
-      </ThemeProvider>
+        </ThemeProvider>
+      </ColorModeProvider>
     </UserProvider>
   );
 }

--- a/src/__tests__/DiagnosticOverlay.test.jsx
+++ b/src/__tests__/DiagnosticOverlay.test.jsx
@@ -2,9 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DiagnosticOverlay from '../pages/matrix-v1/DiagnosticOverlay';
 import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
 import { realMatrixNodes } from '../pages/matrix-v1/realMatrixFlow';
 
-const Wrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
+const Wrapper = ({ children }) => (
+  <ColorModeProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </ColorModeProvider>
+);
 
 test('opens and closes diagnostic overlay', () => {
   render(

--- a/src/__tests__/MapD3Metrics.test.jsx
+++ b/src/__tests__/MapD3Metrics.test.jsx
@@ -2,12 +2,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MapD3 from '../pages/matrix-v1/MapD3';
 import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
 
 jest.mock('../pages/matrix-v1/useTreeLayout', () => {
   return jest.fn(() => ({ drawTree: jest.fn(), rootPosRef: { current: { x: 0, y: 0 } } }));
 });
 
-const Wrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
+const Wrapper = ({ children }) => (
+  <ColorModeProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </ColorModeProvider>
+);
 
 test('toggle metrics overlay button works', () => {
   render(

--- a/src/__tests__/MatrixLayout.test.jsx
+++ b/src/__tests__/MatrixLayout.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
 import MatrixLayout, { MatrixCard, MatrixButton, MatrixInput } from '../components/MatrixLayout';
 import { themes } from '../theme/themes';
 
@@ -13,9 +14,11 @@ jest.mock('../components/MatrixRain', () => {
 });
 
 const TestWrapper = ({ children }) => (
-  <ThemeProvider>
-    {children}
-  </ThemeProvider>
+  <ColorModeProvider>
+    <ThemeProvider>
+      {children}
+    </ThemeProvider>
+  </ColorModeProvider>
 );
 
 describe('MatrixLayout', () => {

--- a/src/__tests__/WorldLayout.test.jsx
+++ b/src/__tests__/WorldLayout.test.jsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
 import WorldLayout from '../components/WorldLayout';
 import { themes } from '../theme/themes';
 
 const Wrapper = ({ children }) => (
-  <ThemeProvider>
-    {children}
-  </ThemeProvider>
+  <ColorModeProvider>
+    <ThemeProvider>
+      {children}
+    </ThemeProvider>
+  </ColorModeProvider>
 );
 
 test('renders children with world background', () => {


### PR DESCRIPTION
## Summary
- wrap ThemeProvider inside ColorModeProvider so ThemeContext can use it
- update tests to include ColorModeProvider

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8ef1d8548326af73d17de0a0ad7d