### PR TITLE
[brian_m] fix missing theme function

### DIFF
--- a/src/theme/ThemeContext.jsx
+++ b/src/theme/ThemeContext.jsx
@@ -203,6 +203,12 @@ export const ThemeProvider = ({ children }) => {
       return colors[colorKey] || '#ffffff';
     },
     getThemeFont: (fontKey) => theme?.fonts?.[fontKey] || 'inherit',
+    getThemeD3: (d3Key) => {
+      const varName = `--d3-${d3Key.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
+      const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+      const num = parseFloat(value);
+      return isNaN(num) ? value : num;
+    },
     getCurrentColors,
     
     // CSS variable helpers


### PR DESCRIPTION
## Summary
- restore `getThemeD3` helper in `ThemeContext`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f909db25883269a25d4b11dccff78