### PR TITLE
[brian_m] fix layering conflicts with navigation bar

### DIFF
--- a/src/pages/matrix-v1/Entry.jsx
+++ b/src/pages/matrix-v1/Entry.jsx
@@ -66,7 +66,7 @@ export default function Entry() {
       <div className="w-full max-w-md space-y-8 text-center relative">
         {/* Active world badge */}
         <div
-          className="absolute top-0 right-0 mt-2 mr-2 px-2 py-1 text-xs rounded border border-theme-accent text-theme-accent bg-theme-glass animate-fade-in"
+          className="absolute top-[64px] right-0 mr-2 px-2 py-1 text-xs rounded border border-theme-accent text-theme-accent bg-theme-glass animate-fade-in"
         >
           {currentWorld.toUpperCase()}
         </div>

--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -118,7 +118,7 @@ export default function MapPage() {
       <h1 className="sr-only">Matrix Story Map</h1>
       
       {/* Narrative Tier Filter */}
-      <div className="fixed top-6 left-6 z-50">
+      <div className="fixed top-[72px] left-6 z-[110]">
         <div className="bg-[#111] border border-purple-400/60 rounded-lg p-4 shadow-[0_0_8px_purple] backdrop-blur-sm">
           <label htmlFor="tier-filter" className="block text-purple-400 font-mono text-sm font-semibold mb-2">
             📖 Narrative Tier Filter
@@ -146,7 +146,7 @@ export default function MapPage() {
       </div>
 
       {/* Scene Path View Drawer */}
-      <div className={`fixed top-0 right-0 h-full z-40 transition-transform duration-300 ease-in-out ${
+      <div className={`fixed top-0 right-0 h-full z-[110] transition-transform duration-300 ease-in-out ${
         drawerOpen ? 'translate-x-0' : 'translate-x-full'
       }`}>
         {/* Drawer Toggle Button */}

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -893,7 +893,7 @@ export default function MapD3() {
           <ZoomControls svgRef={svgRef} />
           
           {/* Help Text */}
-          <div className="absolute top-4 left-4 bg-black/80 text-xs text-gray-400 p-3 rounded border border-gray-600 font-mono">
+          <div className="absolute top-[72px] left-4 bg-black/80 text-xs text-gray-400 p-3 rounded border border-gray-600 font-mono z-[110]">
             <div>🖱️ Click nodes to explore</div>
             <div>🔍 Scroll to zoom</div>
             <div>✋ Drag to pan</div>

--- a/src/pages/matrix-v1/MatrixNamePrompt.jsx
+++ b/src/pages/matrix-v1/MatrixNamePrompt.jsx
@@ -514,7 +514,7 @@ export default function MatrixNamePrompt() {
   return (
     <MatrixLayout>
       {/* View Toggle */}
-      <div className="absolute top-4 right-4 z-10">
+      <div className="absolute top-4 right-4 z-[110]">
         <div className="flex items-center gap-2 bg-theme-secondary border border-theme-accent rounded-lg p-2">
           <span className={`text-xs font-mono ${viewMode === 'enhanced' ? 'text-theme-bright' : 'text-theme-muted'}`}>
             UI

--- a/src/pages/matrix-v1/NightCityBouncer.jsx
+++ b/src/pages/matrix-v1/NightCityBouncer.jsx
@@ -67,7 +67,7 @@ export default function NightCityBouncer() {
     <div className="min-h-screen bg-gradient-to-br from-purple-950 via-black to-pink-950 text-white p-6 font-mono relative overflow-hidden">
       {/* Neon ambiance */}
       <div className="absolute inset-0 bg-grid-cyberpunk opacity-20"></div>
-      <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse"></div>
+      <div className="absolute top-[72px] left-0 w-full h-1 bg-gradient-to-r from-purple-500 to-pink-500 animate-pulse"></div>
       
       <div className="relative z-10 max-w-4xl mx-auto">
         {/* Phase 0: Arriving at the club */}

--- a/src/pages/matrix-v1/NightCityEntry.jsx
+++ b/src/pages/matrix-v1/NightCityEntry.jsx
@@ -48,7 +48,7 @@ export default function NightCityEntry() {
       )}
       
       {/* Neon lights effects */}
-      <div className="absolute top-0 left-0 w-full h-2 bg-gradient-to-r from-purple-500 via-pink-500 to-cyan-500 animate-pulse"></div>
+      <div className="absolute top-[72px] left-0 w-full h-2 bg-gradient-to-r from-purple-500 via-pink-500 to-cyan-500 animate-pulse"></div>
       <div className="absolute bottom-0 left-0 w-full h-2 bg-gradient-to-r from-cyan-500 via-pink-500 to-purple-500 animate-pulse"></div>
       
       <div className="relative z-10 max-w-4xl mx-auto">

--- a/src/pages/matrix-v1/OracleSeekers.jsx
+++ b/src/pages/matrix-v1/OracleSeekers.jsx
@@ -265,7 +265,7 @@ export default function OracleSeekers() {
         )}
 
         {/* Wisdom Quotes Sidebar */}
-        <div className="fixed top-4 right-4 bg-blue-900/50 border border-blue-400/30 rounded-lg p-4 w-64 backdrop-blur-sm">
+        <div className="fixed top-4 right-4 z-[110] bg-blue-900/50 border border-blue-400/30 rounded-lg p-4 w-64 backdrop-blur-sm">
           <h4 className="text-blue-400 font-bold mb-2">💫 Wisdom of the Oracle</h4>
           <div className="text-xs text-gray-300 space-y-2">
             {wisdomQuotes.slice(0, Math.min(wisdom, wisdomQuotes.length)).map((quote, index) => (


### PR DESCRIPTION
## Summary
- bump overlay z-index on Oracle seeker sidebar, scene path drawer, and name prompt toggle
- offset tier filter and gradient bars below the nav bar
- nudge active world badge downward
- adjust help text overlay positioning in D3 map

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdf53acd883269f906e16f425386a