### PR TITLE
[brian_m] Improve summary fallback handling

### DIFF
--- a/src/__tests__/getNodeSummary.test.js
+++ b/src/__tests__/getNodeSummary.test.js
@@ -1,0 +1,28 @@
+import { getNodeSummary } from '../utils/getNodeSummary';
+
+const mockGetWorldDialogue = (dialogue) => Array.isArray(dialogue) ? dialogue : Object.values(dialogue).flat();
+
+test('returns summary when present', () => {
+  const data = { summary: 'hello', description: 'desc', setting: 'here' };
+  expect(getNodeSummary(data, 'matrix', mockGetWorldDialogue)).toBe('hello');
+});
+
+test('falls back to description', () => {
+  const data = { description: 'desc', setting: 'here' };
+  expect(getNodeSummary(data, 'matrix', mockGetWorldDialogue)).toBe('desc');
+});
+
+test('falls back to setting', () => {
+  const data = { setting: 'here' };
+  expect(getNodeSummary(data, 'matrix', mockGetWorldDialogue)).toBe('here');
+});
+
+test('uses dialogue length', () => {
+  const data = { dialogue: ['a', 'b', 'c'] };
+  expect(getNodeSummary(data, 'matrix', mockGetWorldDialogue)).toBe('3 dialogue lines');
+});
+
+test('returns null when missing', () => {
+  const data = {};
+  expect(getNodeSummary(data, 'matrix', mockGetWorldDialogue)).toBeNull();
+});

--- a/src/pages/matrix-v1/QualityDashboard.jsx
+++ b/src/pages/matrix-v1/QualityDashboard.jsx
@@ -16,6 +16,7 @@ import { useTheme } from '../../theme/ThemeContext';
 import { useColorMode } from '../../theme/ColorModeContext';
 import DiagnosticOverlay from './DiagnosticOverlay';
 import { getWorldDialogue, getWorldSummary, getWorldCharacters } from '../../utils/worldContentLoader';
+import { getNodeSummary } from '../../utils/getNodeSummary';
 
 // Status icon mapping
 const STATUS_ICONS = {
@@ -328,7 +329,15 @@ const ExecutiveNodeCard = ({ node, onView, onEdit }) => {
             </h3>
           </div>
           <p className="text-xs text-theme-muted mb-2 leading-relaxed">
-            {node.data?.summary || 'No summary available'}
+            {(() => {
+              const summary = getNodeSummary(node.data, currentWorld, getWorldDialogue);
+              if (summary) return summary;
+              return (
+                <span title="This node lacks summary, description, and setting information">
+                  ⚠️ Missing summary.
+                </span>
+              );
+            })()}
           </p>
         </div>
       </div>

--- a/src/utils/getNodeSummary.js
+++ b/src/utils/getNodeSummary.js
@@ -1,0 +1,14 @@
+export const getNodeSummary = (data, currentWorld, getWorldDialogueFn = null) => {
+  if (!data) return null;
+  if (data.summary) return data.summary;
+  if (data.description) return data.description;
+  if (data.setting) return data.setting;
+  if (data.dialogue) {
+    const getWorldDialogue = getWorldDialogueFn || ((d) => (Array.isArray(d) ? d : Object.values(d).flat()));
+    const lines = Array.isArray(data.dialogue)
+      ? data.dialogue.length
+      : getWorldDialogue(data.dialogue, currentWorld).length;
+    if (lines > 0) return `${lines} dialogue line${lines !== 1 ? 's' : ''}`;
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- implement `getNodeSummary` utility with fallback logic
- show warning icon with tooltip when nodes lack summary data
- cover summary logic with unit tests

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fef846c9c8326b961a508923130e7