### PR TITLE
[brian_m] Add missing summary filter to QualityDashboard

### DIFF
--- a/src/__tests__/QualityDashboardMissingSummaryFilter.test.jsx
+++ b/src/__tests__/QualityDashboardMissingSummaryFilter.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import QualityDashboard from '../pages/matrix-v1/QualityDashboard';
+
+test('missing summary filter toggles node results', async () => {
+  render(
+    <MemoryRouter>
+      <QualityDashboard />
+    </MemoryRouter>
+  );
+  const statusText = await screen.findByText(/Showing/);
+  const initial = statusText.textContent;
+  const checkbox = screen.getByLabelText(/Show nodes missing summaries/i);
+  await userEvent.click(checkbox);
+  const afterClick = await screen.findByText(/Showing/);
+  expect(afterClick.textContent).not.toEqual(initial);
+});

--- a/src/pages/matrix-v1/QualityDashboard.jsx
+++ b/src/pages/matrix-v1/QualityDashboard.jsx
@@ -793,6 +793,7 @@ export default function QualityDashboard() {
   const [selectedWorlds, setSelectedWorlds] = useState(['matrix', 'witcher', 'nightcity']);
   const [selectedStatuses, setSelectedStatuses] = useState(['live', 'wip', 'stub']);
   const [selectedPriorities, setSelectedPriorities] = useState(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']);
+  const [showMissingSummaries, setShowMissingSummaries] = useState(false);
   const [worldFilterCollapsed, setWorldFilterCollapsed] = useState(false);
   const [showMore, setShowMore] = useState(false);
   const [sortConfig, setSortConfig] = useState([{ key: 'updatedAt', direction: 'desc' }]);
@@ -834,9 +835,15 @@ export default function QualityDashboard() {
       const priority = quality.priority || 'LOW';
       if (!selectedPriorities.includes(priority)) return false;
 
+      // Optional filter for nodes missing summary/description
+      if (showMissingSummaries) {
+        const hasSummary = Boolean(node.data?.summary || node.data?.description);
+        if (hasSummary) return false;
+      }
+
       return true;
     });
-  }, [selectedWorlds, selectedStatuses, selectedPriorities]);
+  }, [selectedWorlds, selectedStatuses, selectedPriorities, showMissingSummaries]);
 
   // Calculate KPIs with consistent status logic
   const kpis = useMemo(() => {
@@ -1057,7 +1064,7 @@ export default function QualityDashboard() {
         </div>
 
         {/* Enhanced Filters */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-8">
           <WorldFilter
             selectedWorlds={selectedWorlds}
             onChange={setSelectedWorlds}
@@ -1092,9 +1099,9 @@ export default function QualityDashboard() {
           {/* Enhanced Priority Filter */}
           <div className="bg-theme-secondary border-2 border-theme-accent rounded-lg p-3 md:sticky top-2">
             <div className="text-theme-bright font-medium mb-3">⚡ Priority</div>
-            <div className="grid grid-cols-2 gap-2">
-              {['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'].map(priority => (
-                <label key={priority} className="flex items-center gap-1 cursor-pointer">
+          <div className="grid grid-cols-2 gap-2">
+            {['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'].map(priority => (
+              <label key={priority} className="flex items-center gap-1 cursor-pointer">
                   <input
                     type="checkbox"
                     checked={selectedPriorities.includes(priority)}
@@ -1111,6 +1118,19 @@ export default function QualityDashboard() {
                 </label>
               ))}
             </div>
+          </div>
+
+          {/* Filter for nodes missing summaries */}
+          <div className="bg-theme-secondary border-2 border-theme-accent rounded-lg p-3 md:sticky top-2 flex items-center">
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showMissingSummaries}
+                onChange={(e) => setShowMissingSummaries(e.target.checked)}
+                className="w-4 h-4 text-theme-primary focus:ring-theme-primary focus:ring-2 rounded border-theme-accent"
+              />
+              <span className="text-sm text-theme-bright">Show nodes missing summaries</span>
+            </label>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add `showMissingSummaries` state toggle
- filter nodes by summary/description when toggle active
- show checkbox to enable this filter
- expand filter grid layout
- test missing summary filter

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff61a15e88326988e2c8fd7641b12