### PR TITLE
[brian_m] fix icon import for progress dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,7 @@ import Factions from './pages/matrix-v1/Factions';
 import Align from './pages/matrix-v1/Align';
 import Stabilize from './pages/matrix-v1/Stabilize';
 import GuardianCall from './pages/matrix-v1/GuardianCall';
+import ProgressDashboard from './pages/matrix-v1/ProgressDashboard';
 
 // Faction Choice Components
 import FactionChoice from './pages/matrix-v1/FactionChoice';
@@ -112,6 +113,7 @@ function AppLayout() {
         <Route path="/matrix-v1/map" element={<Map />} />
         <Route path="/matrix-v1/map-d3" element={<MapD3 />} />
         <Route path="/matrix-v1/quality-dashboard" element={<QualityDashboard />} />
+        <Route path="/matrix-v1/progress" element={<ProgressDashboard />} />
         <Route path="/matrix-v1/node-editor" element={<NodeEditor />} />
         <Route path="/matrix-v1/deeper-profile" element={<DeeperProfile />} />
         <Route path="/matrix-v1/interference" element={<Interference />} />

--- a/src/__tests__/ProgressDashboard.test.jsx
+++ b/src/__tests__/ProgressDashboard.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MetricsHeader from '../components/visualizers/MetricsHeader';
+import VisualizerFrame from '../components/visualizers/VisualizerFrame';
+import { useMetricsStore } from '../store/metricsSlice';
+
+test('snapshot metrics header and visualizer', () => {
+  useMetricsStore.setState({
+    cleanliness: 50,
+    stubRatio: 0.5,
+    rulesApplied: 3,
+    recentUpgrades: [],
+    history: [],
+  });
+  const { asFragment } = render(
+    <>
+      <MetricsHeader />
+      <VisualizerFrame mode="tiles" />
+    </>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('cleanliness percentage displays from store', () => {
+  useMetricsStore.setState({ cleanliness: 42, stubRatio: 0.1, rulesApplied: 0, recentUpgrades: [], history: [] });
+  render(<MetricsHeader />);
+  expect(screen.getByText('42%')).toBeInTheDocument();
+});

--- a/src/components/visualizers/AnimationPicker.jsx
+++ b/src/components/visualizers/AnimationPicker.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function AnimationPicker({ mode, onChange }) {
+  const options = [
+    { id: 'tiles', label: 'Tiles' },
+    { id: 'bars', label: 'Bars' },
+    { id: 'nodes', label: 'Nodes' },
+  ];
+  return (
+    <div className="flex space-x-2">
+      {options.map((opt) => (
+        <button
+          key={opt.id}
+          className={`px-3 py-1 rounded-full text-sm transition-colors ${mode === opt.id ? 'bg-green-600 text-white' : 'bg-gray-700 text-gray-300'}`}
+          onClick={() => onChange(opt.id)}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/visualizers/BarsVisualizer.jsx
+++ b/src/components/visualizers/BarsVisualizer.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+const BAR_COUNT = 5;
+
+export default function BarsVisualizer() {
+  const [levels, setLevels] = useState(() => Array(BAR_COUNT).fill(0));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLevels((lvls) => lvls.map(() => Math.random()));
+    }, 700);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex items-end justify-around w-full h-full">
+      {levels.map((lvl, idx) => (
+        <div
+          key={idx}
+          className="w-6 bg-gradient-to-t from-blue-500 to-cyan-400"
+          style={{ height: `${Math.round(lvl * 100)}%`, transition: 'height 0.5s' }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/visualizers/MetricsHeader.jsx
+++ b/src/components/visualizers/MetricsHeader.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useMetricsStore } from '../../store/metricsSlice';
+import { selectProgressMetrics } from '../../store/metricsSlice';
+
+function Donut({ ratio }) {
+  const radius = 16;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - ratio);
+  return (
+    <svg width="40" height="40" className="rotate-[-90deg]">
+      <circle
+        cx="20"
+        cy="20"
+        r={radius}
+        fill="transparent"
+        stroke="#e5e7eb"
+        strokeWidth="4"
+      />
+      <circle
+        cx="20"
+        cy="20"
+        r={radius}
+        fill="transparent"
+        stroke="#10b981"
+        strokeWidth="4"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export default function MetricsHeader() {
+  const { cleanliness, stubRatio, rulesApplied } = useMetricsStore(selectProgressMetrics);
+  const percent = Math.round(cleanliness);
+  const livePercent = Math.round(stubRatio * 100);
+  return (
+    <div className="rounded-2xl bg-white/90 shadow-lg p-6 backdrop-blur flex justify-around">
+      <div className="text-center">
+        <div className="text-2xl font-bold">{percent}%</div>
+        <div className="text-sm text-gray-500">Cleanliness</div>
+      </div>
+      <div className="text-center flex flex-col items-center">
+        <Donut ratio={stubRatio} />
+        <div className="text-sm text-gray-500 mt-1">{livePercent}% live</div>
+      </div>
+      <div className="text-center">
+        <div className="text-2xl font-bold">{rulesApplied}</div>
+        <div className="text-sm text-gray-500">Rules</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/visualizers/NodesVisualizer.jsx
+++ b/src/components/visualizers/NodesVisualizer.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from 'react';
+
+export default function NodesVisualizer() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    let animationId;
+    let nodes = Array.from({ length: 20 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: 2 + Math.random() * 3,
+    }));
+
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      nodes.forEach((n) => {
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(34,197,94,0.8)';
+        ctx.fill();
+        n.r += Math.sin(Date.now() / 200) * 0.02;
+      });
+      animationId = requestAnimationFrame(draw);
+    }
+    draw();
+    return () => cancelAnimationFrame(animationId);
+  }, []);
+
+  return <canvas ref={canvasRef} width={300} height={120} />;
+}

--- a/src/components/visualizers/ProgressControls.jsx
+++ b/src/components/visualizers/ProgressControls.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { FaPlay, FaPause, FaStop } from 'react-icons/fa';
+
+export default function ProgressControls({ playing, onPlay, onPause, onReset, speed, onSpeed }) {
+  return (
+    <div className="flex items-center space-x-3">
+      {playing ? (
+        <button onClick={onPause} aria-label="pause">
+          <FaPause className="w-5 h-5" />
+        </button>
+      ) : (
+        <button onClick={onPlay} aria-label="play">
+          <FaPlay className="w-5 h-5" />
+        </button>
+      )}
+      <button onClick={onReset} aria-label="reset">
+        <FaStop className="w-5 h-5" />
+      </button>
+      <input
+        type="range"
+        min="0.5"
+        max="2"
+        step="0.1"
+        value={speed}
+        onChange={(e) => onSpeed(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}

--- a/src/components/visualizers/RecentUpgradesList.jsx
+++ b/src/components/visualizers/RecentUpgradesList.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useMetricsStore } from '../../store/metricsSlice';
+import { selectProgressMetrics } from '../../store/metricsSlice';
+
+export default function RecentUpgradesList() {
+  const { recentUpgrades } = useMetricsStore(selectProgressMetrics);
+
+  if (!recentUpgrades.length) {
+    return <div className="text-center text-sm text-gray-500">Ready to clean your data</div>;
+  }
+
+  return (
+    <ul className="space-y-1 text-sm">
+      {recentUpgrades.map((u) => (
+        <li key={u.id} className="animate-fade-in">
+          {u.world} — {new Date(u.ts).toLocaleTimeString()}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/visualizers/TilesVisualizer.jsx
+++ b/src/components/visualizers/TilesVisualizer.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+
+const rows = 8;
+const cols = 16;
+
+function randomState() {
+  const states = ['dirty', 'processing', 'clean'];
+  return states[Math.floor(Math.random() * states.length)];
+}
+
+export default function TilesVisualizer() {
+  const [cells, setCells] = useState(() => Array(rows * cols).fill('dirty'));
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCells((c) =>
+        c.map((state) => {
+          if (state === 'dirty' && Math.random() < 0.2) return 'processing';
+          if (state === 'processing' && Math.random() < 0.3) return 'clean';
+          return state;
+        })
+      );
+    }, 500);
+    return () => clearInterval(interval);
+  }, []);
+
+  const getColor = (state) => {
+    if (state === 'clean') return 'bg-green-500 scale-105';
+    if (state === 'processing') return 'bg-yellow-400 animate-pulse';
+    return 'bg-red-500';
+  };
+
+  return (
+    <div
+      className="grid gap-0.5 w-full h-full"
+      style={{ gridTemplateColumns: `repeat(${cols}, minmax(0,1fr))` }}
+    >
+      {cells.map((state, idx) => (
+        <div
+          key={idx}
+          className={`w-full h-full ${getColor(state)}`}
+          style={{ aspectRatio: '1 / 1' }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/visualizers/VisualizerFrame.jsx
+++ b/src/components/visualizers/VisualizerFrame.jsx
@@ -1,0 +1,18 @@
+import React, { Suspense } from 'react';
+import TilesVisualizer from './TilesVisualizer';
+import BarsVisualizer from './BarsVisualizer';
+const NodesVisualizer = React.lazy(() => import('./NodesVisualizer'));
+
+export default function VisualizerFrame({ mode }) {
+  return (
+    <div className="rounded-2xl bg-white/90 shadow-lg backdrop-blur p-4 h-64 flex items-center justify-center">
+      {mode === 'tiles' && <TilesVisualizer />}
+      {mode === 'bars' && <BarsVisualizer />}
+      {mode === 'nodes' && (
+        <Suspense fallback={<div>Loading...</div>}>
+          <NodesVisualizer />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/src/pages/StartPage.jsx
+++ b/src/pages/StartPage.jsx
@@ -15,7 +15,7 @@ const WORLD_OPTIONS = [
     border: 'border-green-400/60',
     glow: 'shadow-[0_0_20px_rgba(34,197,94,0.4)]',
     hoverGlow: 'hover:shadow-[0_0_30px_rgba(34,197,94,0.6)]',
-    features: ['Digital Awakening', 'Choice & Consequence', 'Reality Hacking']
+    features: ['Digital Awakening', 'Choice & Consequence', 'Reality Hacking', 'Progress Dashboard']
   },
   {
     id: 'witcher',
@@ -42,6 +42,19 @@ const WORLD_OPTIONS = [
     glow: 'shadow-[0_0_20px_rgba(147,51,234,0.4)]',
     hoverGlow: 'hover:shadow-[0_0_30px_rgba(147,51,234,0.6)]',
     features: ['Corporate Intrigue', 'Netrunning', 'Street Credibility']
+  },
+  {
+    id: 'progress',
+    name: 'Progress Dashboard',
+    description: 'Visualize cleansing momentum across worlds.',
+    route: '/matrix-v1/progress',
+    theme: 'matrix',
+    icon: '📈',
+    background: 'bg-gradient-to-br from-gray-700/20 to-green-700/20',
+    border: 'border-green-400/60',
+    glow: 'shadow-[0_0_20px_rgba(34,197,94,0.4)]',
+    hoverGlow: 'hover:shadow-[0_0_30px_rgba(34,197,94,0.6)]',
+    features: ['Metrics', 'Animations', 'Data Upgrades']
   }
 ];
 

--- a/src/pages/matrix-v1/ProgressDashboard.jsx
+++ b/src/pages/matrix-v1/ProgressDashboard.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import MatrixLayout from '../../components/MatrixLayout';
+import MetricsHeader from '../../components/visualizers/MetricsHeader';
+import AnimationPicker from '../../components/visualizers/AnimationPicker';
+import VisualizerFrame from '../../components/visualizers/VisualizerFrame';
+import ProgressControls from '../../components/visualizers/ProgressControls';
+import RecentUpgradesList from '../../components/visualizers/RecentUpgradesList';
+
+export default function ProgressDashboard() {
+  const [mode, setMode] = useState('tiles');
+  const [playing, setPlaying] = useState(true);
+  const [speed, setSpeed] = useState(1);
+
+  return (
+    <MatrixLayout fullHeight={false} contentClassName="p-6 space-y-6">
+      <div className="max-w-3xl w-full space-y-6">
+        <MetricsHeader />
+        <AnimationPicker mode={mode} onChange={setMode} />
+        <VisualizerFrame mode={mode} />
+        <ProgressControls
+          playing={playing}
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onReset={() => setMode('tiles')}
+          speed={speed}
+          onSpeed={setSpeed}
+        />
+        <RecentUpgradesList />
+      </div>
+    </MatrixLayout>
+  );
+}

--- a/src/store/metricsSlice.js
+++ b/src/store/metricsSlice.js
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+
+const initialState = {
+  cleanliness: 0,
+  stubRatio: 0,
+  rulesApplied: 0,
+  recentUpgrades: [],
+  history: [],
+};
+
+export const useMetricsStore = create((set) => ({
+  ...initialState,
+  setMetrics: (metrics) =>
+    set((state) => ({
+      ...state,
+      ...metrics,
+    })),
+  addUpgrade: (upgrade) =>
+    set((state) => ({
+      recentUpgrades: [upgrade, ...state.recentUpgrades].slice(0, 5),
+    })),
+  recordSnapshot: () =>
+    set((state) => ({
+      history: [
+        ...state.history,
+        {
+          ts: Date.now(),
+          cleanliness: state.cleanliness,
+          stubRatio: state.stubRatio,
+          rulesApplied: state.rulesApplied,
+        },
+      ],
+    })),
+}));
+
+export const selectProgressMetrics = (state) => ({
+  cleanliness: state.cleanliness,
+  stubRatio: state.stubRatio,
+  rulesApplied: state.rulesApplied,
+  recentUpgrades: state.recentUpgrades,
+  history: state.history,
+});


### PR DESCRIPTION
## Summary
- replace lucide-react icons with react-icons in ProgressControls

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd14168c83269184e381f161cfd7