### PR TITLE
[brian_m] remove unused props from MapCanvas

### DIFF
--- a/src/pages/matrix-v1/Map.jsx
+++ b/src/pages/matrix-v1/Map.jsx
@@ -2,16 +2,7 @@ import React, { useState, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import 'reactflow/dist/base.css';
 import { nodes } from './nodes';
-import { edges } from './edges';
-import { SceneNode, DialogueNode, ChoiceNode, EndingNode } from './CustomNode';
 import MapCanvas from './MapCanvas';
-
-const nodeTypes = {
-  scene: SceneNode,
-  dialogue: DialogueNode,
-  choice: ChoiceNode,
-  ending: EndingNode
-};
 
 const commit = process.env.REACT_APP_GIT_SHA;
 
@@ -300,8 +291,6 @@ export default function MapPage() {
       <MapCanvas
         ref={mapCanvasRef}
         nodes={filteredNodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- cleanup `Map.jsx` by removing unused `edges` and `nodeTypes` props

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400c65b5888326a6fefd6d510e9e41