### PR TITLE
[brian_m] Add Afterlife interior scene and fix Night City transition

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,6 +69,8 @@ import NightCityBouncer from './pages/matrix-v1/NightCityBouncer';
 import NightCityNetdiver from './pages/matrix-v1/NightCityNetdiver';
 import NightCityFile from './pages/matrix-v1/NightCityFile';
 import NightCityAccessConfirmed from './pages/matrix-v1/NightCityAccessConfirmed';
+import AfterlifeAccessGranted from './pages/matrix-v1/night-city/AfterlifeAccessGranted';
+import AfterlifeInterior from './pages/matrix-v1/night-city/AfterlifeInterior';
 
 // Witcher routes
 import WitcherEntry from './pages/witcher/WitcherEntry';
@@ -145,6 +147,8 @@ function AppLayout() {
         {/* Night City routes */}
         <Route path="/matrix-v1/night-city/entry" element={<NightCityEntry />} />
         <Route path="/matrix-v1/night-city/bouncer" element={<NightCityBouncer />} />
+        <Route path="/matrix-v1/night-city/afterlife-access-granted" element={<AfterlifeAccessGranted />} />
+        <Route path="/matrix-v1/night-city/afterlife-interior" element={<AfterlifeInterior />} />
         <Route path="/matrix-v1/night-city/netdiver" element={<NightCityNetdiver />} />
         <Route path="/matrix-v1/night-city/file" element={<NightCityFile />} />
         <Route path="/matrix-v1/night-city/access-confirmed" element={<NightCityAccessConfirmed />} />

--- a/src/__tests__/AfterlifeAccessGranted.test.jsx
+++ b/src/__tests__/AfterlifeAccessGranted.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import AfterlifeAccessGranted from '../pages/matrix-v1/night-city/AfterlifeAccessGranted';
+import AfterlifeInterior from '../pages/matrix-v1/night-city/AfterlifeInterior';
+
+test('CTA navigates to Afterlife interior', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matrix-v1/night-city/afterlife-access-granted']}>
+      <Routes>
+        <Route path="/matrix-v1/night-city/afterlife-access-granted" element={<AfterlifeAccessGranted />} />
+        <Route path="/matrix-v1/night-city/afterlife-interior" element={<AfterlifeInterior />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  await userEvent.click(screen.getByRole('link', { name: /enter the afterlife/i }));
+  expect(await screen.findByText(/afterlife interior/i)).toBeInTheDocument();
+});

--- a/src/pages/matrix-v1/night-city/AfterlifeAccessGranted.jsx
+++ b/src/pages/matrix-v1/night-city/AfterlifeAccessGranted.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useTheme } from '../../theme/ThemeContext';
+
+export default function AfterlifeAccessGranted() {
+  const { setWorld } = useTheme();
+
+  useEffect(() => {
+    setWorld('nightcity');
+  }, [setWorld]);
+
+  return (
+    <div className="min-h-screen text-white p-6 font-mono bg-gradient-to-br from-purple-950 via-black to-pink-950">
+      <div className="max-w-xl mx-auto space-y-8 text-center">
+        <h1 className="text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-500 to-cyan-400">
+          ✅ Access Granted
+        </h1>
+        <p className="text-gray-300">The bouncer steps aside, ushering you into the Afterlife.</p>
+        <Link
+          to="/matrix-v1/night-city/afterlife-interior"
+          className="px-8 py-4 bg-gradient-to-r from-purple-600 via-pink-600 to-cyan-600 hover:from-purple-700 hover:via-pink-700 hover:to-cyan-700 text-white rounded-lg transition-all duration-300 transform hover:scale-105 shadow-lg shadow-purple-500/30"
+        >
+          Enter the Afterlife
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/AfterlifeInterior.jsx
+++ b/src/pages/matrix-v1/night-city/AfterlifeInterior.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../../theme/ThemeContext';
+
+export default function AfterlifeInterior() {
+  const navigate = useNavigate();
+  const { setWorld } = useTheme();
+
+  useEffect(() => {
+    setWorld('nightcity');
+  }, [setWorld]);
+
+  const proceed = () => {
+    const progress = JSON.parse(localStorage.getItem('matrixProgress') || '{}');
+    progress.completedNodes = [...(progress.completedNodes || []), 'nc-afterlife-interior'];
+    localStorage.setItem('matrixProgress', JSON.stringify(progress));
+    navigate('/matrix-v1/night-city/netdiver');
+  };
+
+  return (
+    <div className="min-h-screen text-white p-6 font-mono bg-gradient-to-br from-purple-950 via-black to-pink-950 relative">
+      <audio autoPlay loop className="hidden">
+        <source src="/sfx/afterlife-ambient.mp3" type="audio/mpeg" />
+      </audio>
+      <div className="max-w-xl mx-auto space-y-8 text-center">
+        <h1 className="text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-500 to-cyan-400">
+          🍸 Afterlife Interior
+        </h1>
+        <p className="text-gray-300">
+          Neon lights flicker across chrome surfaces as the bass rumbles from deep within the lounge.
+        </p>
+        <button
+          onClick={proceed}
+          className="px-8 py-4 bg-gradient-to-r from-purple-600 via-pink-600 to-cyan-600 hover:from-purple-700 hover:via-pink-700 hover:to-cyan-700 text-white rounded-lg transition-all duration-300 transform hover:scale-105 shadow-lg shadow-purple-500/30"
+        >
+          Jack into the Net
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/realMatrixFlow.js
+++ b/src/pages/matrix-v1/realMatrixFlow.js
@@ -1524,7 +1524,9 @@ const rawMatrixNodes = [
   
   // Night City internal flow
   { id: 'edge-nc-entry-to-bouncer', source: 'nc-entry', target: 'nc-bouncer' },
-  { id: 'edge-nc-bouncer-to-netdiver', source: 'nc-bouncer', target: 'nc-netdiver', label: 'Access Granted' },
+  { id: 'edge-nc-bouncer-to-afterlife-granted', source: 'nc-bouncer', target: 'nc-afterlife-access-granted', label: 'Access Granted' },
+  { id: 'edge-afterlife-granted-to-interior', source: 'nc-afterlife-access-granted', target: 'nc-afterlife-interior' },
+  { id: 'edge-afterlife-interior-to-netdiver', source: 'nc-afterlife-interior', target: 'nc-netdiver' },
   { id: 'edge-nc-bouncer-to-escape', source: 'nc-bouncer', target: 'nc-escape', label: 'Fight Started' },
   { id: 'edge-nc-netdiver-to-file', source: 'nc-netdiver', target: 'nc-file', label: 'Data Stolen' },
   { id: 'edge-nc-file-to-silverhand', source: 'nc-file', target: 'nc-silverhand', label: 'Truth Revealed' },
@@ -1972,6 +1974,21 @@ const rawMatrixNodes = [
         }
       }
     }
+  }
+  ,
+  {
+    id: 'nc-afterlife-access-granted',
+    displayName: 'Afterlife Access Granted',
+    type: 'scene',
+    narrativeTier: 'mid',
+    enhancement: { priority: 'medium' }
+  },
+  {
+    id: 'nc-afterlife-interior',
+    displayName: 'Afterlife Interior',
+    type: 'scene',
+    narrativeTier: 'mid',
+    enhancement: { priority: 'medium' }
   }
 ];
 


### PR DESCRIPTION
## Summary
- add missing Afterlife Access Granted page and Afterlife Interior scene
- link new routes into Night City flow
- include graph nodes and edges for new scenes
- test CTA navigation to Afterlife Interior

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684077d787e48326a0fb3b85e3a6a458