### PR TITLE
[brian_m] add night city node stubs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,15 @@ import NightCityFile from './pages/matrix-v1/NightCityFile';
 import NightCityAccessConfirmed from './pages/matrix-v1/NightCityAccessConfirmed';
 import AfterlifeAccessGranted from './pages/matrix-v1/night-city/AfterlifeAccessGranted';
 import AfterlifeInterior from './pages/matrix-v1/night-city/AfterlifeInterior';
+import NcEntry from './pages/matrix-v1/night-city/NcEntry';
+import NcBouncer from './pages/matrix-v1/night-city/NcBouncer';
+import NcNetdiver from './pages/matrix-v1/night-city/NcNetdiver';
+import NcEscape from './pages/matrix-v1/night-city/NcEscape';
+import NcFile from './pages/matrix-v1/night-city/NcFile';
+import NcSilverhand from './pages/matrix-v1/night-city/NcSilverhand';
+import NcArchiveDive from './pages/matrix-v1/night-city/NcArchiveDive';
+import NcNeutralEnding from './pages/matrix-v1/night-city/NcNeutralEnding';
+import NcControlEnding from './pages/matrix-v1/night-city/NcControlEnding';
 
 // Witcher routes
 import WitcherEntry from './pages/witcher/WitcherEntry';
@@ -152,6 +161,15 @@ function AppLayout() {
         <Route path="/matrix-v1/night-city/netdiver" element={<NightCityNetdiver />} />
         <Route path="/matrix-v1/night-city/file" element={<NightCityFile />} />
         <Route path="/matrix-v1/night-city/access-confirmed" element={<NightCityAccessConfirmed />} />
+        <Route path="/matrix-v1/night-city/nc-entry" element={<NcEntry />} />
+        <Route path="/matrix-v1/night-city/nc-bouncer" element={<NcBouncer />} />
+        <Route path="/matrix-v1/night-city/nc-netdiver" element={<NcNetdiver />} />
+        <Route path="/matrix-v1/night-city/nc-escape" element={<NcEscape />} />
+        <Route path="/matrix-v1/night-city/nc-file" element={<NcFile />} />
+        <Route path="/matrix-v1/night-city/nc-silverhand" element={<NcSilverhand />} />
+        <Route path="/matrix-v1/night-city/nc-archive-dive" element={<NcArchiveDive />} />
+        <Route path="/matrix-v1/night-city/nc-neutral-ending" element={<NcNeutralEnding />} />
+        <Route path="/matrix-v1/night-city/nc-control-ending" element={<NcControlEnding />} />
 
         {/* Witcher routes */}
         <Route path="/witcher/entry" element={<WitcherEntry />} />

--- a/src/pages/matrix-v1/night-city/NcArchiveDive.jsx
+++ b/src/pages/matrix-v1/night-city/NcArchiveDive.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcArchiveDive() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Archive Dive</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcBouncer.jsx
+++ b/src/pages/matrix-v1/night-city/NcBouncer.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcBouncer() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Bouncer</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcControlEnding.jsx
+++ b/src/pages/matrix-v1/night-city/NcControlEnding.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcControlEnding() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Control Ending</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcEntry.jsx
+++ b/src/pages/matrix-v1/night-city/NcEntry.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcEntry() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Entry</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcEscape.jsx
+++ b/src/pages/matrix-v1/night-city/NcEscape.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcEscape() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Escape</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcFile.jsx
+++ b/src/pages/matrix-v1/night-city/NcFile.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcFile() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc File</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcNetdiver.jsx
+++ b/src/pages/matrix-v1/night-city/NcNetdiver.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcNetdiver() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Netdiver</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcNeutralEnding.jsx
+++ b/src/pages/matrix-v1/night-city/NcNeutralEnding.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcNeutralEnding() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Neutral Ending</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/night-city/NcSilverhand.jsx
+++ b/src/pages/matrix-v1/night-city/NcSilverhand.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NcSilverhand() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Nc Silverhand</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/realMatrixFlow.js
+++ b/src/pages/matrix-v1/realMatrixFlow.js
@@ -1989,7 +1989,88 @@ const rawMatrixNodes = [
     type: 'scene',
     narrativeTier: 'mid',
     enhancement: { priority: 'medium' }
-  }
+  },
+  {
+    id: 'nc-entry',
+    displayName: 'Nc Entry',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-bouncer',
+    displayName: 'Nc Bouncer',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-netdiver',
+    displayName: 'Nc Netdiver',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-escape',
+    displayName: 'Nc Escape',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-file',
+    displayName: 'Nc File',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-silverhand',
+    displayName: 'Nc Silverhand',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-archive-dive',
+    displayName: 'Nc Archive Dive',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-neutral-ending',
+    displayName: 'Nc Neutral Ending',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'nc-control-ending',
+    displayName: 'Nc Control Ending',
+    type: 'scene',
+    world: 'night-city',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
 ];
 
 // Provide simple default positions so new nodes render even without layout


### PR DESCRIPTION
## Summary
- add missing Night City stub nodes to `realMatrixFlow.js`
- generate placeholder pages for each stub
- register stub routes in the app

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm start` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407a53c2d88326aa1245d2d15426b6