### PR TITLE
[brian_m] Use realMatrixFlow data for D3 map

### DIFF
--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import * as d3 from 'd3';
-import { nodes as realMatrixNodes } from './nodes';
-import { edges as realMatrixEdges } from './edges';
+import { realMatrixNodes as rawMatrixNodes, realMatrixEdges } from './realMatrixFlow';
+import { migrateLegacyNodes } from '../../utils/migrateLegacyNodes';
 import { convertToTree, filterTreeByStatus, findPathToNode, validateTreeNoCycles, analyzeTree } from '../../utils/convertToTree';
 import { useTheme } from '../../theme/ThemeContext';
 import { useLocation, useSearchParams } from 'react-router-dom';
@@ -11,6 +11,8 @@ import DetailPanel from './DetailPanel';
 import ZoomControls from './ZoomControls';
 import DiagnosticOverlay from './DiagnosticOverlay';
 import { getWorldCharacters } from '../../utils/worldContentLoader';
+
+const realMatrixNodes = migrateLegacyNodes(rawMatrixNodes);
 
 const LAYOUT_TYPES = {
   tree: 'tree',

--- a/src/utils/migrateLegacyNodes.js
+++ b/src/utils/migrateLegacyNodes.js
@@ -1,0 +1,16 @@
+export function migrateLegacyNodes(nodes) {
+  return nodes.map((n) => {
+    const migrated = { ...n };
+    migrated.data = { ...migrated.data };
+    if (migrated.displayName && !migrated.data.title) {
+      migrated.data.title = migrated.displayName;
+    }
+    if (!migrated.status && migrated.data.status) {
+      migrated.status = migrated.data.status;
+    }
+    if (migrated.status && !migrated.data.status) {
+      migrated.data.status = migrated.status;
+    }
+    return migrated;
+  });
+}


### PR DESCRIPTION
## Summary
- switch D3 Map to load nodes/edges from `realMatrixFlow.js`
- migrate legacy nodes so fields like `displayName` map to `title`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684080092acc8326862af078143673c7