### PR TITLE
[brian_m] support multi-root D3 story map

### DIFF
--- a/src/__tests__/ConvertToTreeMultiRoot.test.js
+++ b/src/__tests__/ConvertToTreeMultiRoot.test.js
@@ -1,0 +1,23 @@
+import { convertToTree } from '../utils/convertToTree';
+import { analyzeTree } from '../utils/convertToTree';
+
+test('convertToTree creates synthetic world root when multiple depth0 nodes', () => {
+  const nodes = [
+    { id: 'matrix-root', depth: 0, type: 'scene' },
+    { id: 'witcher-root', depth: 0, type: 'scene' },
+    { id: 'child', depth: 1, type: 'scene' }
+  ];
+  const edges = [
+    { source: 'matrix-root', target: 'child' }
+  ];
+
+  const tree = convertToTree(nodes, edges);
+
+  expect(tree.id).toBe('world-root');
+  expect(tree.children.map(c => c.id)).toEqual(expect.arrayContaining(['matrix-root','witcher-root']));
+
+  const stats = analyzeTree(tree);
+  const oldMax = Math.max(...nodes.map(n => n.depth));
+  expect(stats.maxDepth).toBe(oldMax + 1);
+});
+

--- a/src/__tests__/MapD3MultiRoot.test.jsx
+++ b/src/__tests__/MapD3MultiRoot.test.jsx
@@ -1,0 +1,44 @@
+import { render, waitFor } from '@testing-library/react';
+import MapD3 from '../pages/matrix-v1/MapD3';
+import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
+
+const mockDraw = jest.fn(() => {
+  const svg = document.querySelector('svg');
+  if (svg) {
+    const a = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    a.setAttribute('data-id', 'nc-bouncer');
+    svg.appendChild(a);
+    const b = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    b.setAttribute('data-id', 'witcher-sign-training');
+    svg.appendChild(b);
+  }
+});
+
+jest.mock('../pages/matrix-v1/useTreeLayout', () => {
+  return jest.fn(() => ({
+    drawTree: mockDraw,
+    rootPosRef: { current: { x: 0, y: 0 } },
+    nodePosRef: { current: { 'nc-bouncer': { x:0, y:0 }, 'witcher-sign-training': { x:0, y:0 } } },
+  }));
+});
+
+const Wrapper = ({ children }) => (
+  <ColorModeProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </ColorModeProvider>
+);
+
+test('multi root nodes appear in SVG', async () => {
+  const { container } = render(
+    <Wrapper>
+      <MapD3 />
+    </Wrapper>
+  );
+
+  await waitFor(() => {
+    expect(container.querySelector('[data-id="nc-bouncer"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-id="witcher-sign-training"]')).toBeInTheDocument();
+  });
+});
+

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -172,7 +172,7 @@ function getInitialExpandedNodes(nodes, edges, rootId = 'matrix-v1-entry') {
 export default function MapD3() {
   const svgRef = useRef();
   const searchInputRef = useRef();
-  const { currentTheme, theme, getThemeD3, currentWorld } = useTheme();
+  const { currentTheme, theme, getThemeD3, currentWorld, setWorld } = useTheme();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const focusNodeId = location.state?.focusNode || searchParams.get('node');
@@ -452,6 +452,19 @@ export default function MapD3() {
 
   // Convert data to tree structure
   const originalTree = convertToTree(realMatrixNodes, realMatrixEdges);
+
+  useEffect(() => {
+    if (originalTree && originalTree.id === 'world-root' && currentWorld !== 'all') {
+      // When multiple top-level worlds exist, show all by default
+      if (typeof setWorld === 'function') {
+        try {
+          setWorld('all');
+        } catch {
+          // setWorld may not accept "all" if theme mapping missing
+        }
+      }
+    }
+  }, [originalTree, currentWorld, setWorld]);
   
   // Validate the tree structure for cycles (development only)
   if (process.env.NODE_ENV === 'development') {

--- a/src/pages/matrix-v1/useTreeLayout.js
+++ b/src/pages/matrix-v1/useTreeLayout.js
@@ -228,6 +228,7 @@ export default function useTreeLayout(params) {
         const radius = typeof nodeRadius === 'function' ? nodeRadius(d) : nodeRadius;
         return radius + 15;
       })
+      .style('display', (d) => (d.data?.id === 'world-root' ? 'none' : null))
       .style('text-anchor', 'start')
       .style('font-size', '12px')
       .style('font-weight', 'bold')

--- a/src/theme/ThemeContext.jsx
+++ b/src/theme/ThemeContext.jsx
@@ -7,9 +7,10 @@ const ThemeContext = createContext();
 // World mappings - each world corresponds to a theme
 const WORLD_THEME_MAP = {
   'matrix': 'matrix',
-  'witcher': 'witcher', 
+  'witcher': 'witcher',
   'nightcity': 'nightcity',
-  'cyberpunk': 'nightcity' // Legacy support
+  'cyberpunk': 'nightcity', // Legacy support
+  'all': 'matrix'
 };
 
 // Reverse mapping for theme to world

--- a/src/utils/convertToTree.js
+++ b/src/utils/convertToTree.js
@@ -57,12 +57,32 @@ export function convertToTree(nodes, edges) {
     }
   });
   
-  // Find the root node (depth 0 or first node if no depth 0)
-  const rootNode = nodes.find(node => node.depth === 0) || nodes[0];
+  // Determine top level nodes
+  const rootCandidates = nodes.filter(node => node.depth === 0);
+
+  // If multiple depth 0 nodes exist, create a synthetic root to group them
+  if (rootCandidates.length > 1) {
+    return {
+      id: 'world-root',
+      type: 'root',
+      depth: -1,
+      group: 'system',
+      data: {
+        title: 'Worlds',
+        description: 'Synthetic root node',
+        status: 'live'
+      },
+      children: rootCandidates.map(n => nodeMap.get(n.id)).filter(Boolean),
+      _originalNode: null
+    };
+  }
+
+  // Otherwise use the single depth 0 node or fallback to first node
+  const rootNode = rootCandidates[0] || nodes[0];
   const root = nodeMap.get(rootNode?.id);
-  
+
   if (!root) {
-    // Fallback: create a synthetic root
+    // Fallback: create a generic root
     return {
       id: 'root',
       type: 'root',
@@ -77,7 +97,7 @@ export function convertToTree(nodes, edges) {
       _originalNode: null
     };
   }
-  
+
   return root;
 }
 


### PR DESCRIPTION
## Summary
- add synthetic world root in `convertToTree`
- hide synthetic root label in the D3 renderer
- auto-switch to `all` world when world root detected
- allow `all` as a world theme
- test multi-root conversion and map rendering

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684082173e3083268fac9ed4caed4731