### PR TITLE
[brian_m] auto enable world filter from deep link

### DIFF
--- a/src/__tests__/MapD3AutoWorld.test.jsx
+++ b/src/__tests__/MapD3AutoWorld.test.jsx
@@ -1,0 +1,48 @@
+import { render, waitFor, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import MapD3 from '../pages/matrix-v1/MapD3';
+import { ThemeProvider, useTheme } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
+
+jest.mock('../pages/matrix-v1/useTreeLayout', () => {
+  return jest.fn(() => ({
+    drawTree: jest.fn(),
+    rootPosRef: { current: { x: 0, y: 0 } },
+    nodePosRef: { current: { 'nc-bouncer': { x: 10, y: 20 } } },
+  }));
+});
+
+const WorldDisplay = () => {
+  const { currentWorld } = useTheme();
+  return <div data-testid="world">{currentWorld}</div>;
+};
+
+const Wrapper = ({ initialEntries }) => (
+  <MemoryRouter initialEntries={initialEntries}>
+    <ColorModeProvider>
+      <ThemeProvider>
+        <Routes>
+          <Route path="/matrix-v1/map-d3" element={<><WorldDisplay /><MapD3 /></>} />
+        </Routes>
+      </ThemeProvider>
+    </ColorModeProvider>
+  </MemoryRouter>
+);
+
+test('deep link switches world and centers on target node', async () => {
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ width: 100, height: 100, top:0, left:0, right:100, bottom:100 }),
+  });
+
+  render(<Wrapper initialEntries={["/matrix-v1/map-d3?node=nc-bouncer"]} />);
+
+  await waitFor(() =>
+    expect(screen.getByTestId('world').textContent).toBe('nightcity')
+  );
+
+  const svg = document.querySelector('svg');
+  await waitFor(() => {
+    expect(svg.__zoom).toMatchObject({ k: 1, x: 40, y: 30 });
+  });
+});

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -575,9 +575,25 @@ export default function MapD3() {
 
   useEffect(() => {
     if (!initialCentered && rootPosRef?.current && svgRef.current) {
-      const target = focusNodeId && nodePosRef.current[focusNodeId]
-        ? nodePosRef.current[focusNodeId]
-        : rootPosRef.current;
+      const targetNode = realMatrixNodes.find((n) => n.id === focusNodeId);
+      const targetWorldRaw = targetNode?.world;
+      const targetWorld = targetWorldRaw?.replace(/-/g, '');
+
+      if (
+        focusNodeId &&
+        targetWorld &&
+        currentWorld !== 'all' &&
+        targetWorld !== 'matrix' &&
+        currentWorld !== targetWorld
+      ) {
+        setWorld(targetWorld);
+        return;
+      }
+
+      const target =
+        focusNodeId && nodePosRef.current[focusNodeId]
+          ? nodePosRef.current[focusNodeId]
+          : rootPosRef.current;
       if (!target) return;
       const { x, y } = target;
       const svgRect = svgRef.current.getBoundingClientRect();
@@ -591,7 +607,7 @@ export default function MapD3() {
         );
       setInitialCentered(true);
     }
-  }, [rootPosRef, nodePosRef, focusNodeId, initialCentered]);
+  }, [rootPosRef, nodePosRef, focusNodeId, initialCentered, currentWorld, setWorld]);
 
   return (
     <div className="min-h-screen bg-[#0a0a0a] text-white flex">


### PR DESCRIPTION
## Summary
- adjust `MapD3` to switch worlds when focusing on a node via deep-link
- add regression test ensuring deep-link switches world and centers map

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b1f9be88326b48952471ba9dc50