### PR TITLE
[brian_m] add overlay toggles to D3 map

### DIFF
--- a/src/__tests__/MapD3OverlayControls.test.jsx
+++ b/src/__tests__/MapD3OverlayControls.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MapD3 from '../pages/matrix-v1/MapD3';
+import { ThemeProvider } from '../theme/ThemeContext';
+import { ColorModeProvider } from '../theme/ColorModeContext';
+
+const mockDraw = jest.fn(() => {
+  const svg = document.querySelector('svg');
+  if (svg) {
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    g.setAttribute('class', 'edges');
+    svg.appendChild(g);
+  }
+});
+
+jest.mock('../pages/matrix-v1/useTreeLayout', () => {
+  return jest.fn(() => ({
+    drawTree: mockDraw,
+    rootPosRef: { current: { x: 0, y: 0 } },
+    nodePosRef: { current: { start: { x: 0, y: 0 }, end: { x: 10, y: 10 } } },
+  }));
+});
+
+const Wrapper = ({ children }) => (
+  <ColorModeProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </ColorModeProvider>
+);
+
+test('edge and real path toggles work', () => {
+  const { container } = render(
+    <Wrapper>
+      <MapD3 />
+    </Wrapper>
+  );
+  const hideToggle = screen.getByLabelText(/hide edges/i);
+  const pathToggle = screen.getByLabelText(/show real path/i);
+  const edgesGroup = container.querySelector('.edges');
+  expect(edgesGroup).toBeInTheDocument();
+  expect(edgesGroup.style.display).toBe('');
+  userEvent.click(hideToggle);
+  expect(edgesGroup.style.display).toBe('none');
+  userEvent.click(pathToggle);
+  expect(container.querySelector('.real-path-overlay')).toBeInTheDocument();
+});

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -10,6 +10,8 @@ import SidebarFilters from './SidebarFilters';
 import DetailPanel from './DetailPanel';
 import ZoomControls from './ZoomControls';
 import DiagnosticOverlay from './DiagnosticOverlay';
+import MapOverlayControls from './MapOverlayControls';
+import { getVisited } from './MatrixRouteMemory';
 import { getWorldCharacters } from '../../utils/worldContentLoader';
 
 const realMatrixNodes = migrateLegacyNodes(rawMatrixNodes);
@@ -207,6 +209,10 @@ export default function MapD3() {
 
   // Metrics overlay toggle
   const [showMetrics, setShowMetrics] = useState(false);
+
+  // Overlay controls
+  const [hideEdges, setHideEdges] = useState(false);
+  const [showRealPath, setShowRealPath] = useState(true);
   
   // Search and UI states
   const [searchQuery, setSearchQuery] = useState('');
@@ -522,6 +528,7 @@ export default function MapD3() {
     selectedNode,
     handleNodeClick,
     showMetrics,
+    hideEdges,
   });
 
   const toggleStatusFilter = (status) => {
@@ -572,6 +579,29 @@ export default function MapD3() {
   useEffect(() => {
     drawTree();
   }, [drawTree]);
+
+  // Draw real user path overlay
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('.real-path-overlay').remove();
+    if (!showRealPath) return;
+    const visited = getVisited();
+    const points = visited
+      .map(id => nodePosRef.current[id])
+      .filter(Boolean)
+      .map(p => `${p.x},${p.y}`)
+      .join(' ');
+    if (points) {
+      svg
+        .append('polyline')
+        .attr('class', 'real-path-overlay')
+        .attr('points', points)
+        .style('fill', 'none')
+        .style('stroke', '#06b6d4')
+        .style('stroke-width', 2)
+        .style('pointer-events', 'none');
+    }
+  }, [showRealPath, drawTree]);
 
   useEffect(() => {
     if (!initialCentered && rootPosRef?.current && svgRef.current) {
@@ -912,9 +942,15 @@ export default function MapD3() {
           <svg
             ref={svgRef}
             className="w-full h-full bg-gradient-to-br from-gray-900 to-black border-l border-green-400/20"
-            style={{ minHeight: '600px' }}
+          style={{ minHeight: '600px' }}
           />
           <ZoomControls svgRef={svgRef} />
+          <MapOverlayControls
+            hideEdges={hideEdges}
+            setHideEdges={setHideEdges}
+            showRealPath={showRealPath}
+            setShowRealPath={setShowRealPath}
+          />
           
           {/* Help Text */}
           <div className="absolute top-[72px] left-4 bg-black/80 text-xs text-gray-400 p-3 rounded border border-gray-600 font-mono z-[110]">

--- a/src/pages/matrix-v1/MapOverlayControls.jsx
+++ b/src/pages/matrix-v1/MapOverlayControls.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function MapOverlayControls({ hideEdges, setHideEdges, showRealPath, setShowRealPath }) {
+  return (
+    <div className="fixed md:top-4 md:right-4 bottom-4 md:bottom-auto left-1/2 md:left-auto -translate-x-1/2 md:translate-x-0 z-50 bg-black/80 border border-cyan-400 rounded-md p-2 text-xs font-mono space-y-1 pointer-events-auto">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={hideEdges}
+          onChange={(e) => setHideEdges(e.target.checked)}
+          className="accent-cyan-500"
+        />
+        <span className="text-cyan-300">Hide Edges</span>
+      </label>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={showRealPath}
+          onChange={(e) => setShowRealPath(e.target.checked)}
+          className="accent-cyan-500"
+        />
+        <span className="text-cyan-300">Show Real Path</span>
+      </label>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/useTreeLayout.js
+++ b/src/pages/matrix-v1/useTreeLayout.js
@@ -37,6 +37,7 @@ export default function useTreeLayout(params) {
     selectedNode,
     handleNodeClick,
     showMetrics,
+    hideEdges,
   } = params;
 
   const rootPosRef = useRef({ x: 0, y: 0 });
@@ -171,27 +172,42 @@ export default function useTreeLayout(params) {
       nodePosRef.current[id] = { x: xPos, y: yPos };
     });
 
-    const linkGroups = g.selectAll('.link').data(links).enter().append('g').attr('class', 'link');
-    const linkPaths = linkGroups
-      .append('path')
-      .attr('d', (d) => {
-        if (layoutType === 'radial') {
-          const sx = d.source.x_cartesian + width / 2;
-          const sy = d.source.y_cartesian + height / 2;
-          const tx = d.target.x_cartesian + width / 2;
-          const ty = d.target.y_cartesian + height / 2;
-          return `M${sx},${sy}L${tx},${ty}`;
-        }
-        if (layoutType === 'tree') {
-          return `M${d.source.y},${d.source.x}C${(d.source.y + d.target.y) / 2},${d.source.x} ${(d.source.y + d.target.y) / 2},${d.target.x} ${d.target.y},${d.target.x}`;
-        }
-        return `M${d.source.x},${d.source.y}L${d.target.x},${d.target.y}`;
-      })
-      .style('fill', 'none')
-      .style('stroke', themeConfigs[currentTheme].linkColor)
-      .style('stroke-width', '2px')
-      .style('opacity', 0.6)
-      .style('stroke-dasharray', layoutType === 'network' ? '3,3' : 'none');
+    const edgesGroup = g.append('g').attr('class', 'edges');
+    if (hideEdges) {
+      edgesGroup.style('display', 'none');
+    } else {
+      edgesGroup.style('display', null);
+    }
+
+    let linkPaths = edgesGroup.selectAll('path');
+    if (!hideEdges) {
+      const linkGroups = edgesGroup
+        .selectAll('.link')
+        .data(links)
+        .enter()
+        .append('g')
+        .attr('class', 'link');
+      linkPaths = linkGroups
+        .append('path')
+        .attr('d', (d) => {
+          if (layoutType === 'radial') {
+            const sx = d.source.x_cartesian + width / 2;
+            const sy = d.source.y_cartesian + height / 2;
+            const tx = d.target.x_cartesian + width / 2;
+            const ty = d.target.y_cartesian + height / 2;
+            return `M${sx},${sy}L${tx},${ty}`;
+          }
+          if (layoutType === 'tree') {
+            return `M${d.source.y},${d.source.x}C${(d.source.y + d.target.y) / 2},${d.source.x} ${(d.source.y + d.target.y) / 2},${d.target.x} ${d.target.y},${d.target.x}`;
+          }
+          return `M${d.source.x},${d.source.y}L${d.target.x},${d.target.y}`;
+        })
+        .style('fill', 'none')
+        .style('stroke', themeConfigs[currentTheme].linkColor)
+        .style('stroke-width', '2px')
+        .style('opacity', 0.6)
+        .style('stroke-dasharray', layoutType === 'network' ? '3,3' : 'none');
+    }
 
     const nodeGroups = g
       .selectAll('.node')
@@ -363,7 +379,7 @@ export default function useTreeLayout(params) {
         nodeGroups.attr('transform', (d) => `translate(${d.x},${d.y})`);
       });
     }
-  }, [svgRef, filteredTree, layoutType, expandedNodes, nodeMatchesFilters, themeConfigs, currentTheme, forceStrength, linkDistance, centerStrength, collideRadius, selectedNode, handleNodeClick, showMetrics]);
+  }, [svgRef, filteredTree, layoutType, expandedNodes, nodeMatchesFilters, themeConfigs, currentTheme, forceStrength, linkDistance, centerStrength, collideRadius, selectedNode, handleNodeClick, showMetrics, hideEdges]);
 
   return { drawTree, rootPosRef, nodePosRef };
 }


### PR DESCRIPTION
## Summary
- expose overlay switches for the D3 story map
- hide edges using `hideEdges` flag in tree layout
- show visited node path via `real-path-overlay`
- add MapOverlayControls component
- test edge and path toggles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408e0323d883268dd16907675f0017