### PR TITLE
[brian_m] normalize overlay z-index

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -241,9 +241,14 @@ code {
 /* Overlay specific optimizations */
 .overlay-group-container {
   padding: 12px 0 0 12px;
-  z-index: 5;
+  z-index: 10;
   pointer-events: none;
   contain: layout style; /* CSS containment for better performance */
+}
+
+.real-path-overlay {
+  z-index: 20;
+  pointer-events: none;
 }
 
 /* Reduce motion for users who prefer it */

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -588,7 +588,9 @@ export default function MapD3() {
         .style('fill', 'none')
         .style('stroke', '#06b6d4')
         .style('stroke-width', 2)
-        .style('pointer-events', 'none');
+        .style('pointer-events', 'none')
+        .style('z-index', 20)
+        .style('position', 'relative');
     }
   }, [showRealPath, drawTree]);
 
@@ -760,7 +762,7 @@ export default function MapD3() {
           <svg
             ref={svgRef}
             className="w-full h-full bg-gradient-to-br from-gray-900 to-black border-l border-green-400/20"
-          style={{ minHeight: '600px' }}
+          style={{ minHeight: '600px', overflow: 'visible' }}
           />
           <ZoomControls svgRef={svgRef} />
           <MapOverlayControls
@@ -771,7 +773,7 @@ export default function MapD3() {
           />
           
           {/* Help Text */}
-          <div className="absolute top-[72px] left-4 bg-black/80 text-xs text-gray-400 p-3 rounded border border-gray-600 font-mono z-[110]">
+          <div className="absolute top-[72px] left-4 bg-black/80 text-xs text-gray-400 p-3 rounded border border-gray-600 font-mono z-30 pointer-events-none">
             <div>🖱️ Click nodes to explore</div>
             <div>🔍 Scroll to zoom</div>
             <div>✋ Drag to pan</div>
@@ -782,7 +784,7 @@ export default function MapD3() {
 
           {/* Active Filters Mini-Display */}
           {activeFilterCount > 0 && (
-            <div className="absolute bottom-4 left-4 bg-black/90 text-xs p-3 rounded border border-purple-400/40 font-mono max-w-xs">
+            <div className="absolute bottom-4 left-4 bg-black/90 text-xs p-3 rounded border border-purple-400/40 font-mono max-w-xs z-30 pointer-events-none">
               <div className="text-purple-400 font-bold mb-1">🎯 Showing filtered results</div>
               <div className="text-gray-300">
                 {activeCharacterFilters.length > 0 && `🎭 ${activeCharacterFilters.length} characters`}

--- a/src/pages/matrix-v1/MapOverlayControls.jsx
+++ b/src/pages/matrix-v1/MapOverlayControls.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function MapOverlayControls({ hideEdges, setHideEdges, showRealPath, setShowRealPath }) {
   return (
-    <div className="fixed md:top-4 md:right-4 bottom-4 md:bottom-auto left-1/2 md:left-auto -translate-x-1/2 md:translate-x-0 z-50 bg-black/80 border border-cyan-400 rounded-md p-2 text-xs font-mono space-y-1 pointer-events-auto">
+    <div className="fixed md:top-4 md:right-4 bottom-4 md:bottom-auto left-1/2 md:left-auto -translate-x-1/2 md:translate-x-0 z-30 bg-black/80 border border-cyan-400 rounded-md p-2 text-xs font-mono space-y-1 pointer-events-auto">
       <label className="flex items-center gap-2">
         <input
           type="checkbox"


### PR DESCRIPTION
## Summary
- ensure MapOverlayControls sits at z-30
- keep SVG overflow visible
- elevate help text and filters overlay to z-30 and disable pointer events
- draw the real path overlay above nodes
- bump overlay-group-container z-index

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840912d3f4c8326b337c774d27c1113