### PR TITLE
[brian_m] feat: add Finance World stub nodes and pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,6 +63,13 @@ import FactionPortal from './pages/matrix-v1/FactionPortal';
 import GlitchPortal from './pages/matrix-v1/GlitchPortal';
 import OracleSeekers from './pages/matrix-v1/OracleSeekers';
 
+// Finance world routes
+import FinEntry from './pages/matrix-v1/finance/FinEntry';
+import FinUploadTerminal from './pages/matrix-v1/finance/FinUploadTerminal';
+import FinCleansingNode from './pages/matrix-v1/finance/FinCleansingNode';
+import FinOpsDashboard from './pages/matrix-v1/finance/FinOpsDashboard';
+import FinCreditsHub from './pages/matrix-v1/finance/FinCreditsHub';
+
 // Night City routes
 import NightCityEntry from './pages/matrix-v1/NightCityEntry';
 import NightCityBouncer from './pages/matrix-v1/NightCityBouncer';
@@ -170,6 +177,13 @@ function AppLayout() {
         <Route path="/matrix-v1/night-city/nc-archive-dive" element={<NcArchiveDive />} />
         <Route path="/matrix-v1/night-city/nc-neutral-ending" element={<NcNeutralEnding />} />
         <Route path="/matrix-v1/night-city/nc-control-ending" element={<NcControlEnding />} />
+
+        {/* Finance routes */}
+        <Route path="/matrix-v1/finance/fin-entry" element={<FinEntry />} />
+        <Route path="/matrix-v1/finance/fin-upload-terminal" element={<FinUploadTerminal />} />
+        <Route path="/matrix-v1/finance/fin-cleansing-node" element={<FinCleansingNode />} />
+        <Route path="/matrix-v1/finance/fin-ops-dashboard" element={<FinOpsDashboard />} />
+        <Route path="/matrix-v1/finance/fin-credits-hub" element={<FinCreditsHub />} />
 
         {/* Witcher routes */}
         <Route path="/witcher/entry" element={<WitcherEntry />} />

--- a/src/pages/matrix-v1/finance/FinCleansingNode.jsx
+++ b/src/pages/matrix-v1/finance/FinCleansingNode.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FinCleansingNode() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Fin Cleansing Node</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/finance/FinCreditsHub.jsx
+++ b/src/pages/matrix-v1/finance/FinCreditsHub.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FinCreditsHub() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Fin Credits Hub</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/finance/FinEntry.jsx
+++ b/src/pages/matrix-v1/finance/FinEntry.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FinEntry() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Fin Entry</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/finance/FinOpsDashboard.jsx
+++ b/src/pages/matrix-v1/finance/FinOpsDashboard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FinOpsDashboard() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Fin Ops Dashboard</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/finance/FinUploadTerminal.jsx
+++ b/src/pages/matrix-v1/finance/FinUploadTerminal.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FinUploadTerminal() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Fin Upload Terminal</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/realMatrixFlow.js
+++ b/src/pages/matrix-v1/realMatrixFlow.js
@@ -2071,10 +2071,51 @@ const rawMatrixNodes = [
     status: 'stub',
     enhancement: { reviewNeeded: true }
   },
+  // === FINANCE WORLD STUB NODES ===
+  {
+    id: 'fin-entry',
+    type: 'scene',
+    world: 'finance',
+    narrativeTier: 'intro',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fin-upload-terminal',
+    type: 'scene',
+    world: 'finance',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fin-cleansing-node',
+    type: 'scene',
+    world: 'finance',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fin-ops-dashboard',
+    type: 'scene',
+    world: 'finance',
+    narrativeTier: 'climax',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fin-credits-hub',
+    type: 'scene',
+    world: 'finance',
+    narrativeTier: 'climax',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
 ];
 
 // Provide simple default positions so new nodes render even without layout
-const worldIndex = { matrix: 0, witcher: 1, nightcity: 2 };
+const worldIndex = { matrix: 0, witcher: 1, nightcity: 2, finance: 3 };
 export const realMatrixNodes = rawMatrixNodes.map((n) => ({
   ...n,
   position: n.position || {


### PR DESCRIPTION
## Summary
- add Finance World pages and routes
- register finance stub nodes in realMatrixFlow
- include Finance world in layout positioning

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095c5956c8326b2fa79878831e2e6