### PR TITLE
[brian_m] add Fallout World stub nodes and pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,6 +88,13 @@ import NcArchiveDive from './pages/matrix-v1/night-city/NcArchiveDive';
 import NcNeutralEnding from './pages/matrix-v1/night-city/NcNeutralEnding';
 import NcControlEnding from './pages/matrix-v1/night-city/NcControlEnding';
 
+// Fallout routes
+import FoVaultEntry from './pages/matrix-v1/fallout/FoVaultEntry';
+import FoFactionChoice from './pages/matrix-v1/fallout/FoFactionChoice';
+import FoWastelandScout from './pages/matrix-v1/fallout/FoWastelandScout';
+import FoDataTerminal from './pages/matrix-v1/fallout/FoDataTerminal';
+import FoMainQuest from './pages/matrix-v1/fallout/FoMainQuest';
+
 // Witcher routes
 import WitcherEntry from './pages/witcher/WitcherEntry';
 import MutationChoice from './pages/witcher/MutationChoice';
@@ -184,6 +191,13 @@ function AppLayout() {
         <Route path="/matrix-v1/finance/fin-cleansing-node" element={<FinCleansingNode />} />
         <Route path="/matrix-v1/finance/fin-ops-dashboard" element={<FinOpsDashboard />} />
         <Route path="/matrix-v1/finance/fin-credits-hub" element={<FinCreditsHub />} />
+
+        {/* Fallout routes */}
+        <Route path="/matrix-v1/fallout/vault-entry" element={<FoVaultEntry />} />
+        <Route path="/matrix-v1/fallout/faction-choice" element={<FoFactionChoice />} />
+        <Route path="/matrix-v1/fallout/wasteland-scout" element={<FoWastelandScout />} />
+        <Route path="/matrix-v1/fallout/data-terminal" element={<FoDataTerminal />} />
+        <Route path="/matrix-v1/fallout/main-quest" element={<FoMainQuest />} />
 
         {/* Witcher routes */}
         <Route path="/witcher/entry" element={<WitcherEntry />} />

--- a/src/pages/matrix-v1/fallout/FoDataTerminal.jsx
+++ b/src/pages/matrix-v1/fallout/FoDataTerminal.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FoDataTerminal() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Data Terminal</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/fallout/FoFactionChoice.jsx
+++ b/src/pages/matrix-v1/fallout/FoFactionChoice.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FoFactionChoice() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Faction Choice</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/fallout/FoMainQuest.jsx
+++ b/src/pages/matrix-v1/fallout/FoMainQuest.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FoMainQuest() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Main Quest</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/fallout/FoVaultEntry.jsx
+++ b/src/pages/matrix-v1/fallout/FoVaultEntry.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FoVaultEntry() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Vault Entry</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/fallout/FoWastelandScout.jsx
+++ b/src/pages/matrix-v1/fallout/FoWastelandScout.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FoWastelandScout() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Wasteland Scout</h1>
+      <p>Under construction.</p>
+    </div>
+  );
+}

--- a/src/pages/matrix-v1/realMatrixFlow.js
+++ b/src/pages/matrix-v1/realMatrixFlow.js
@@ -2112,10 +2112,51 @@ const rawMatrixNodes = [
     status: 'stub',
     enhancement: { reviewNeeded: true }
   },
+  // === FALLOUT WORLD STUB NODES ===
+  {
+    id: 'fo-vault-entry',
+    type: 'scene',
+    world: 'fallout',
+    narrativeTier: 'intro',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fo-faction-choice',
+    type: 'scene',
+    world: 'fallout',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fo-wasteland-scout',
+    type: 'scene',
+    world: 'fallout',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fo-data-terminal',
+    type: 'scene',
+    world: 'fallout',
+    narrativeTier: 'mid',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
+  {
+    id: 'fo-main-quest',
+    type: 'scene',
+    world: 'fallout',
+    narrativeTier: 'climax',
+    status: 'stub',
+    enhancement: { reviewNeeded: true }
+  },
 ];
 
 // Provide simple default positions so new nodes render even without layout
-const worldIndex = { matrix: 0, witcher: 1, nightcity: 2, finance: 3 };
+const worldIndex = { matrix: 0, witcher: 1, nightcity: 2, finance: 3, fallout: 4 };
 export const realMatrixNodes = rawMatrixNodes.map((n) => ({
   ...n,
   position: n.position || {


### PR DESCRIPTION
## Summary
- add Fallout World stub nodes in `realMatrixFlow.js`
- include Fallout in the world index mapping
- create placeholder Fallout pages
- wire up new routes for Fallout scenes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409a493cbc8326958789fdcb1e322d