### PR TITLE
[brian_m] add Finance world to QualityDashboard filters

### DIFF
--- a/src/pages/matrix-v1/DiagnosticOverlay.jsx
+++ b/src/pages/matrix-v1/DiagnosticOverlay.jsx
@@ -34,6 +34,11 @@ const WORLD_GROUPS = {
     name: 'Night City',
     icon: '🌆',
     groups: ['night-city', 'nightcity', 'corpo', 'street', 'nomad']
+  },
+  finance: {
+    name: 'Finance',
+    icon: '💰',
+    groups: ['finance']
   }
 };
 

--- a/src/pages/matrix-v1/QualityDashboard.jsx
+++ b/src/pages/matrix-v1/QualityDashboard.jsx
@@ -67,6 +67,14 @@ const WORLD_GROUPS = {
     borderColor: 'border-theme-primary',
     groups: ['night-city', 'nightcity', 'corpo', 'street', 'nomad']
   }
+  ,
+  'finance': {
+    name: 'Finance',
+    icon: '💰',
+    color: 'text-theme-primary',
+    borderColor: 'border-theme-primary',
+    groups: ['finance']
+  }
 };
 
 // Utility function to get node world - checks node.world first, then group lookup
@@ -776,7 +784,7 @@ export default function QualityDashboard() {
   const { colorMode } = useColorMode();
   
   // State management
-  const [selectedWorlds, setSelectedWorlds] = useState(['matrix', 'witcher', 'nightcity']);
+  const [selectedWorlds, setSelectedWorlds] = useState(['matrix', 'witcher', 'nightcity', 'finance']);
   const [selectedStatuses, setSelectedStatuses] = useState(['live', 'wip', 'stub']);
   const [selectedPriorities, setSelectedPriorities] = useState(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']);
   const [showMissingSummaries, setShowMissingSummaries] = useState(false);


### PR DESCRIPTION
## Summary
- include Finance world in WORLD_GROUPS used by QualityDashboard and DiagnosticOverlay
- default to showing Finance nodes in QualityDashboard filters

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409c29577083268e6897c0e5738073