### PR TITLE
[brian_m] enable fallout world in dashboard

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -37,7 +37,8 @@ export default function Navigation() {
     'matrix': { icon: '💊', label: 'MATRIX', color: 'text-green-400 border-green-400' },
     'witcher': { icon: '⚔️', label: 'WITCHER', color: 'text-amber-400 border-amber-400' },
     'nightcity': { icon: '🌆', label: 'NIGHT_CITY', color: 'text-purple-400 border-purple-400' },
-    'cyberpunk': { icon: '🌆', label: 'NIGHT_CITY', color: 'text-purple-400 border-purple-400' } // Legacy support
+    'cyberpunk': { icon: '🌆', label: 'NIGHT_CITY', color: 'text-purple-400 border-purple-400' }, // Legacy support
+    'fallout': { icon: '☢️', label: 'FALLOUT', color: 'text-lime-400 border-lime-400' }
   };
 
   const worldDisplay = worldDisplays[currentWorld] || worldDisplays.matrix;

--- a/src/pages/matrix-v1/DiagnosticOverlay.jsx
+++ b/src/pages/matrix-v1/DiagnosticOverlay.jsx
@@ -35,6 +35,11 @@ const WORLD_GROUPS = {
     icon: '🌆',
     groups: ['night-city', 'nightcity', 'corpo', 'street', 'nomad']
   },
+  fallout: {
+    name: 'Fallout',
+    icon: '☢️',
+    groups: ['fallout']
+  },
   finance: {
     name: 'Finance',
     icon: '💰',

--- a/src/pages/matrix-v1/MapD3.jsx
+++ b/src/pages/matrix-v1/MapD3.jsx
@@ -250,6 +250,14 @@ export default function MapD3() {
       nodeColor: getThemeD3('nodeColor') || '#a855f7',
       linkColor: getThemeD3('linkColor') || '#c084fc',
       gridOpacity: getThemeD3('gridOpacity') || 0.4
+    },
+    fallout: {
+      bgColor: 'bg-neutral-900',
+      primaryColor: 'text-lime-400',
+      accentColor: 'text-yellow-400',
+      nodeColor: getThemeD3('nodeColor') || '#84cc16',
+      linkColor: getThemeD3('linkColor') || '#a3e635',
+      gridOpacity: getThemeD3('gridOpacity') || 0.3
     }
   }), [getThemeD3]);
 

--- a/src/pages/matrix-v1/QualityDashboard.jsx
+++ b/src/pages/matrix-v1/QualityDashboard.jsx
@@ -68,6 +68,13 @@ const WORLD_GROUPS = {
     groups: ['night-city', 'nightcity', 'corpo', 'street', 'nomad']
   }
   ,
+  'fallout': {
+    name: 'Fallout',
+    icon: '☢️',
+    color: 'text-theme-primary',
+    borderColor: 'border-theme-primary',
+    groups: ['fallout']
+  },
   'finance': {
     name: 'Finance',
     icon: '💰',
@@ -784,7 +791,7 @@ export default function QualityDashboard() {
   const { colorMode } = useColorMode();
   
   // State management
-  const [selectedWorlds, setSelectedWorlds] = useState(['matrix', 'witcher', 'nightcity', 'finance']);
+  const [selectedWorlds, setSelectedWorlds] = useState(['matrix', 'witcher', 'nightcity', 'fallout', 'finance']);
   const [selectedStatuses, setSelectedStatuses] = useState(['live', 'wip', 'stub']);
   const [selectedPriorities, setSelectedPriorities] = useState(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']);
   const [showMissingSummaries, setShowMissingSummaries] = useState(false);

--- a/src/theme/ThemeContext.jsx
+++ b/src/theme/ThemeContext.jsx
@@ -10,6 +10,7 @@ const WORLD_THEME_MAP = {
   'witcher': 'witcher',
   'nightcity': 'nightcity',
   'cyberpunk': 'nightcity', // Legacy support
+  'fallout': 'matrix',
   'all': 'matrix'
 };
 

--- a/src/theme/themes.js
+++ b/src/theme/themes.js
@@ -333,6 +333,9 @@ export const themes = {
   }
 };
 
+// Fallout uses Matrix theme colors by default
+themes.fallout = { ...themes.matrix, name: 'Fallout', id: 'fallout' };
+
 export const getThemeVariables = (themeId, colorMode = 'dark') => {
   const theme = themes[themeId];
   if (!theme) return {};


### PR DESCRIPTION
## Summary
- include Fallout in world groups and world filter defaults
- map Fallout world to Matrix theme
- show Fallout icon in navigation
- support Fallout theming in MapD3 and theme configs

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2330b088326a52ae412580e532e