### PR TITLE
[brian_m] Fallout stub path fleshed out

### DIFF
--- a/src/pages/matrix-v1/fallout/FoDataTerminal.jsx
+++ b/src/pages/matrix-v1/fallout/FoDataTerminal.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default function FoDataTerminal() {
   return (
-    <div className="p-4 text-center">
-      <h1 className="text-2xl font-bold">Data Terminal</h1>
-      <p>Under construction.</p>
+    <div className="p-4 space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Abandoned Data Terminal</h1>
+      <p>
+        A flicker of static bursts from the dusty monitor. You decipher
+        coordinates to an untouched vault hidden beyond the mountains.
+      </p>
+      <Link to="/matrix-v1/fallout/main-quest" className="text-blue-300 underline">
+        Download the data
+      </Link>
     </div>
   );
 }

--- a/src/pages/matrix-v1/fallout/FoFactionChoice.jsx
+++ b/src/pages/matrix-v1/fallout/FoFactionChoice.jsx
@@ -1,10 +1,21 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function FoFactionChoice() {
+  const navigate = useNavigate();
+
+  const goNext = () => navigate('/matrix-v1/fallout/wasteland-scout');
+
   return (
-    <div className="p-4 text-center">
-      <h1 className="text-2xl font-bold">Faction Choice</h1>
-      <p>Under construction.</p>
+    <div className="p-4 space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Choose Your Allegiance</h1>
+      <p>Three groups vie for your skills. Whose banner will you carry?</p>
+
+      <div className="space-y-2">
+        <button onClick={goNext} className="px-4 py-2 bg-gray-700 rounded">Brotherhood of Steel</button>
+        <button onClick={goNext} className="px-4 py-2 bg-gray-700 rounded">Raiders</button>
+        <button onClick={goNext} className="px-4 py-2 bg-gray-700 rounded">Stay Independent</button>
+      </div>
     </div>
   );
 }

--- a/src/pages/matrix-v1/fallout/FoMainQuest.jsx
+++ b/src/pages/matrix-v1/fallout/FoMainQuest.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 
 export default function FoMainQuest() {
   return (
-    <div className="p-4 text-center">
-      <h1 className="text-2xl font-bold">Main Quest</h1>
-      <p>Under construction.</p>
+    <div className="p-4 space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Path to the Future</h1>
+      <p>
+        Armed with the recovered data, your faction prepares for the decisive
+        journey ahead. The fate of the wastes now rests on your choices.
+      </p>
     </div>
   );
 }

--- a/src/pages/matrix-v1/fallout/FoVaultEntry.jsx
+++ b/src/pages/matrix-v1/fallout/FoVaultEntry.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default function FoVaultEntry() {
   return (
-    <div className="p-4 text-center">
-      <h1 className="text-2xl font-bold">Vault Entry</h1>
-      <p>Under construction.</p>
+    <div className="p-4 space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Emerging from the Vault</h1>
+      <p>
+        The heavy door slides shut behind you. Sunlight burns your eyes as you
+        take your first breath of the surface world. The wastes sprawl out in
+        ruins and opportunity.
+      </p>
+      <Link to="/matrix-v1/fallout/faction-choice" className="text-blue-300 underline">
+        Step into the wasteland
+      </Link>
     </div>
   );
 }

--- a/src/pages/matrix-v1/fallout/FoWastelandScout.jsx
+++ b/src/pages/matrix-v1/fallout/FoWastelandScout.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default function FoWastelandScout() {
   return (
-    <div className="p-4 text-center">
+    <div className="p-4 space-y-4 text-center">
       <h1 className="text-2xl font-bold">Wasteland Scout</h1>
-      <p>Under construction.</p>
+      <p>
+        You spend days combing ruined buildings and dusty roads, gathering what
+        supplies and rumors you can for your faction.
+      </p>
+      <Link to="/matrix-v1/fallout/data-terminal" className="text-blue-300 underline">
+        Report your findings
+      </Link>
     </div>
   );
 }

--- a/src/pages/matrix-v1/realMatrixFlow.js
+++ b/src/pages/matrix-v1/realMatrixFlow.js
@@ -2118,40 +2118,80 @@ const rawMatrixNodes = [
     type: 'scene',
     world: 'fallout',
     narrativeTier: 'intro',
-    status: 'stub',
-    enhancement: { reviewNeeded: true }
+    data: {
+      title: 'Vault Exit',
+      pageUrl: '/matrix-v1/fallout/vault-entry',
+      status: 'live',
+      summary: 'You step into the sunlight for the first time and behold the desolate wasteland.',
+      characters: ['Lone Survivor'],
+      puzzles: [],
+      interactions: [],
+      features: { hasTransition: true }
+    }
   },
   {
     id: 'fo-faction-choice',
-    type: 'scene',
+    type: 'choice',
     world: 'fallout',
     narrativeTier: 'mid',
-    status: 'stub',
-    enhancement: { reviewNeeded: true }
+    data: {
+      title: 'Faction Negotiations',
+      pageUrl: '/matrix-v1/fallout/faction-choice',
+      status: 'live',
+      summary: 'Representatives of three groups ask for your loyalty in exchange for protection.',
+      characters: ['Faction Leaders'],
+      puzzles: [],
+      interactions: ['ChoicePrompt'],
+      features: { hasChoice: true, hasTransition: true }
+    }
   },
   {
     id: 'fo-wasteland-scout',
     type: 'scene',
     world: 'fallout',
     narrativeTier: 'mid',
-    status: 'stub',
-    enhancement: { reviewNeeded: true }
+    data: {
+      title: 'Wasteland Scout Mission',
+      pageUrl: '/matrix-v1/fallout/wasteland-scout',
+      status: 'live',
+      summary: 'You scour nearby ruins for supplies and gather intel for your chosen faction.',
+      characters: ['Lone Survivor'],
+      puzzles: ['Scavenge'],
+      interactions: [],
+      features: { hasTransition: true }
+    }
   },
   {
     id: 'fo-data-terminal',
     type: 'scene',
     world: 'fallout',
     narrativeTier: 'mid',
-    status: 'stub',
-    enhancement: { reviewNeeded: true }
+    data: {
+      title: 'Abandoned Data Terminal',
+      pageUrl: '/matrix-v1/fallout/data-terminal',
+      status: 'live',
+      summary: 'An old terminal reveals coordinates to a hidden vault with valuable technology.',
+      characters: ['Lone Survivor'],
+      puzzles: [],
+      interactions: ['DataDownload'],
+      features: { hasTransition: true }
+    }
   },
   {
     id: 'fo-main-quest',
     type: 'scene',
     world: 'fallout',
     narrativeTier: 'climax',
-    status: 'stub',
-    enhancement: { reviewNeeded: true }
+    data: {
+      title: 'Toward the Future',
+      pageUrl: '/matrix-v1/fallout/main-quest',
+      status: 'live',
+      summary: 'With new knowledge in hand, the real adventure begins.',
+      characters: ['Lone Survivor'],
+      puzzles: [],
+      interactions: [],
+      features: { hasTransition: true }
+    }
   },
 ];
 
@@ -2180,5 +2220,13 @@ export const realMatrixEdges = [
   { id: 'edge-witcher-entry-to-mutation', source: 'witcher-entry', target: 'witcher-mutation-choice' },
   { id: 'edge-witcher-mutation-to-signs', source: 'witcher-mutation-choice', target: 'witcher-sign-training', label: 'Trial Survived' },
   { id: 'edge-witcher-signs-to-final-ritual', source: 'witcher-sign-training', target: 'witcher-final-ritual', label: 'Final Trial Beckons' },
-  { id: 'edge-witcher-trial-to-final-ritual', source: 'witcher-trial-of-reflection', target: 'witcher-final-ritual', label: 'Elder Circle Calls' }
+  { id: 'edge-witcher-trial-to-final-ritual', source: 'witcher-trial-of-reflection', target: 'witcher-final-ritual', label: 'Elder Circle Calls' },
+
+  // Fallout world flow
+  { id: 'edge-fo-entry-to-choice', source: 'fo-vault-entry', target: 'fo-faction-choice' },
+  { id: 'edge-fo-choice-brotherhood', source: 'fo-faction-choice', target: 'fo-wasteland-scout', label: 'Brotherhood of Steel' },
+  { id: 'edge-fo-choice-raiders', source: 'fo-faction-choice', target: 'fo-wasteland-scout', label: 'Raiders' },
+  { id: 'edge-fo-choice-independent', source: 'fo-faction-choice', target: 'fo-wasteland-scout', label: 'Independent' },
+  { id: 'edge-fo-scout-to-terminal', source: 'fo-wasteland-scout', target: 'fo-data-terminal' },
+  { id: 'edge-fo-terminal-to-main', source: 'fo-data-terminal', target: 'fo-main-quest' }
 ];


### PR DESCRIPTION
## Summary
- fill in Fallout intro nodes with playable text and summaries
- connect Fallout nodes with edges representing a basic faction choice path
- update React components for Vault Entry, Faction Choice, Wasteland Scout, Data Terminal, and Main Quest

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a68391948326b28bf650c62e87b0