### PR TITLE
[brian_m] Add blueprint docs placeholders

### DIFF
--- a/docs/blueprints/btc_dashboard.md
+++ b/docs/blueprints/btc_dashboard.md
@@ -1,0 +1,3 @@
+# Dad Ticker – BTC Dashboard Planning
+
+This placeholder document is awaiting the latest content from the Canvas source.

--- a/docs/blueprints/laurel_rental_tool.md
+++ b/docs/blueprints/laurel_rental_tool.md
@@ -1,0 +1,3 @@
+# Laurel AG – Asset Rental Tool
+
+Awaiting details from the Canvas document. Replace this placeholder with actual content once retrieved.

--- a/docs/blueprints/life_hud_spec.md
+++ b/docs/blueprints/life_hud_spec.md
@@ -1,0 +1,3 @@
+# Life HUD – Task Tracker Spec
+
+This file is a placeholder. Update with information from the Canvas document when available.

--- a/docs/blueprints/matrix_narrative_log.md
+++ b/docs/blueprints/matrix_narrative_log.md
@@ -1,0 +1,3 @@
+# Matrix Narrative Engine – Live Dev Stream Log
+
+This placeholder document notes that the latest content from the Canvas document is not available in this repository. Please update with the correct information when accessible.

--- a/docs/blueprints/retail_command.md
+++ b/docs/blueprints/retail_command.md
@@ -1,0 +1,3 @@
+# Retail Command – Ecom Portal Notes
+
+Latest notes from Canvas were not found in this repository. Replace this text with the updated documentation when available.

--- a/docs/blueprints/theme_engine.md
+++ b/docs/blueprints/theme_engine.md
@@ -1,0 +1,3 @@
+# Brian_M Theme Engine + Routing System
+
+Content from the Canvas document was not located. Please provide the latest spec here when possible.


### PR DESCRIPTION
## Summary
- create `/docs/blueprints/` with placeholder markdown for upcoming docs

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b0121a28832686464dcf6dde4a2f